### PR TITLE
Add vesting wallet contracts

### DIFF
--- a/contracts/token/VestingBase.sol
+++ b/contracts/token/VestingBase.sol
@@ -1,0 +1,24 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity ^0.8.11;
+
+import "@openzeppelin/contracts-upgradeable/finance/VestingWalletUpgradeable.sol";
+
+/** 
+    * @title Provides a base implementation of the vesting wallet to be used by `VestingFactory`
+*/
+contract VestingBase is VestingWalletUpgradeable {
+
+    constructor() initializer {return;}
+
+    function initialize(
+        address _beneficiaryAddress,
+        uint64 _startTimestamp,
+        uint64 _durationSeconds
+    ) public initializer {
+        __VestingWallet_init(
+            _beneficiaryAddress,
+            _startTimestamp,
+            _durationSeconds
+        );
+    }
+}

--- a/contracts/token/VestingFactory.sol
+++ b/contracts/token/VestingFactory.sol
@@ -1,0 +1,31 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity ^0.8.11;
+
+import "./VestingBase.sol";
+import "@openzeppelin/contracts/proxy/Clones.sol";
+
+///@title Creates vesting contracts based on `VestingBase` implementation
+contract VestingFactory {
+    address private immutable baseImplementation;
+    event VestingWalletCreated(address indexed beneficiaryAddress, uint64 startTimestamp, uint64 durationSeconds, address indexed vestingWalletAddress);
+
+    constructor () {
+        baseImplementation = address(new VestingBase());
+    }
+
+    /// @dev The newly created wallet should have zero balance
+    function createVestingSchedule(       
+        address _beneficiaryAddress,
+        uint64 _startTimestamp,
+        uint64 _durationSeconds
+    ) external returns (address) {
+        address clone = Clones.clone(baseImplementation);
+        VestingBase(payable(clone)).initialize(
+            _beneficiaryAddress,
+            _startTimestamp,
+            _durationSeconds
+        );
+        emit VestingWalletCreated(_beneficiaryAddress, _startTimestamp, _durationSeconds, clone);
+        return clone;
+    }
+}


### PR DESCRIPTION
## Description
Vesting can be a good feature to add to strengthen thirdweb's governance product suite. I included some very simple and bare-bone implementations of vesting contracts to open up a discussion.

## How does vesting work?
Basically, one would specify a `startTimestamp`, from which the beneficiary is eligible to receive payouts. The period between now and `startTimestamp` is what people usually refer to as the "cliff". 

After the cliff, the beneficiary will be able to receive tokens at an interval and an amount-per-interval defined by the contract logic.

[<img src="https://miro.medium.com/max/1400/1*434uMpFQxH6_MnobD-Ixig.png">](https://medium.com/cardstack/building-a-token-vesting-contract-b368a954f99)
_Source: [Building a Token Vesting Contract](https://medium.com/cardstack/building-a-token-vesting-contract-b368a954f99)_

OpenZeppelin's [default implementation](https://github.com/OpenZeppelin/openzeppelin-contracts/blob/v4.5.0/contracts/finance/VestingWallet.sol) for vesting logic is a linear function with respect to the amount of time passed since `startTimestamp` and the total amount of tokens in the vesting contract. 
```solidity
    function _vestingSchedule(uint256 totalAllocation, uint64 timestamp) internal view virtual returns (uint256) {
        if (timestamp < start()) {
            return 0;
        } else if (timestamp > start() + duration()) {
            return totalAllocation;
        } else {
            return (totalAllocation * (timestamp - start())) / duration();
        }
    }
```

Of course, we can give users the ability to design their own vesting logics.

## Usage (Illustrative)
The `VestingFactory` is used to produce and deploy empty wallets (contracts) based on some base implementation, `VestingBase`, by calling a factory method `createVestingSchedule`. Arguments needed to pass in are:
* `address _beneficiaryAddress`: the address of the account entitled to vesting
* `uint64 _startTimestamp`: when does vesting begin
* `uint64 _durationSeconds`: how long does it take to fully vest

The following pseudocode illustrate how to deploy and effectuate a vesting wallet.

```js
var erc20Token = deploy(Token);
var factory = deploy(VestingFactory); 
var wallet = factory.createVestingSchedule(beneficiaryAddress, startTimestamp, durationSeconds);

await erc20Token.transfer(wallet, amount); 

for (every month; up until startTimestamp + durationSeconds) {
    wallet.release();
}
```
Note that if we want to set an automatic release schedule on-chain, we'd need an Oracle solution.

## Epilogue
There are lots of creative use cases for vesting. And I think if we can develop a set of SDKs to allow clients easily create and customize vesting, then thirdweb can attract more organizational users like large DAOs.

A robust governance product offering also paves the road for DeFi SDK offerings, if that's on the roadmap.