### PR TITLE
Auction buyout fix

### DIFF
--- a/contracts/marketplace/Marketplace.sol
+++ b/contracts/marketplace/Marketplace.sol
@@ -504,9 +504,9 @@ contract Marketplace is
             _closeAuctionForBidder(_targetListing, _incomingBid);
         } else {
             /**
-            *      If there's an exisitng winning bid, incoming bid amount must be bid buffer % greater.
-            *      Else, bid amount must be at least as great as reserve price
-            */
+             *      If there's an exisitng winning bid, incoming bid amount must be bid buffer % greater.
+             *      Else, bid amount must be at least as great as reserve price
+             */
             require(
                 isNewWinningBid(
                     _targetListing.reservePricePerToken * _targetListing.quantity,
@@ -515,7 +515,7 @@ contract Marketplace is
                 ),
                 "not winning bid."
             );
-            
+
             // Update the winning bid and listing's end time before external contract calls.
             winningBid[_targetListing.listingId] = _incomingBid;
 
@@ -537,22 +537,22 @@ contract Marketplace is
         }
 
         // Collect incoming bid
-            CurrencyTransferLib.transferCurrencyWithWrapperAndBalanceCheck(
-                _targetListing.currency,
-                _incomingBid.offeror,
-                address(this),
-                incomingOfferAmount,
-                _nativeTokenWrapper
-            );
+        CurrencyTransferLib.transferCurrencyWithWrapperAndBalanceCheck(
+            _targetListing.currency,
+            _incomingBid.offeror,
+            address(this),
+            incomingOfferAmount,
+            _nativeTokenWrapper
+        );
 
-            emit NewOffer(
-                _targetListing.listingId,
-                _incomingBid.offeror,
-                _targetListing.listingType,
-                _incomingBid.quantityWanted,
-                _incomingBid.pricePerToken * _incomingBid.quantityWanted,
-                _incomingBid.currency
-            );
+        emit NewOffer(
+            _targetListing.listingId,
+            _incomingBid.offeror,
+            _targetListing.listingType,
+            _incomingBid.quantityWanted,
+            _incomingBid.pricePerToken * _incomingBid.quantityWanted,
+            _incomingBid.currency
+        );
     }
 
     /// @dev Checks whether an incoming bid is the new current highest bid.

--- a/src/test/Marketplace.sol
+++ b/src/test/Marketplace.sol
@@ -143,4 +143,51 @@ contract MarketplaceTest is BaseTest {
         assertEq(winningBid.currency, NATIVE_TOKEN);
         assertEq(winningBid.pricePerToken, 2 ether);
     }
+
+    function test_closeAuctionForCreator_afterBuyout() public {
+        
+        vm.deal(getActor(0), 100 ether);
+        vm.deal(getActor(1), 100 ether);
+
+        // Actor-0 creates an auction listing.
+        vm.startPrank(getActor(0));
+        (uint256 listingId, ) = createERC721Listing(
+            getActor(0),
+            NATIVE_TOKEN,
+            5 ether,
+            IMarketplace.ListingType.Auction
+        );
+
+        Marketplace.Listing memory listing = getListing(listingId);
+        assertEq(erc721.ownerOf(listing.tokenId), address(marketplace));
+        assertEq(weth.balanceOf(address(marketplace)), 0);
+
+        /**
+         *  Actor-1 bids with buyout price. Outcome:
+         *      - Actor-1 receives auctioned items escrowed in Marketplace.
+         *      - Winning bid amount is escrowed in the contract.
+         */
+        vm.warp(1);
+        vm.prank(getActor(1));
+        marketplace.offer{ value: 5 ether }(listingId, 1, NATIVE_TOKEN, 5 ether);
+
+        assertEq(erc721.ownerOf(listing.tokenId), getActor(1));
+        assertEq(weth.balanceOf(address(marketplace)), 5 ether);
+
+        /**
+         *  Auction is closed for the auction creator i.e. Actor-0. Outcome:
+         *      - Actor-0 receives the escrowed buyout amount.
+         */
+        
+        uint256 listerBalBefore = getActor(0).balance;
+
+        vm.warp(2);
+        marketplace.closeAuction(listingId, getActor(0));
+        
+        uint256 listerBalAfter = getActor(0).balance;
+        uint256 winningBidPostFee = (5 ether * (MAX_BPS - platformFeeBps)) / MAX_BPS;
+
+        assertEq(listerBalAfter - listerBalBefore, winningBidPostFee);
+        assertEq(weth.balanceOf(address(marketplace)), 0);
+    }
 }

--- a/src/test/Marketplace.sol
+++ b/src/test/Marketplace.sol
@@ -145,7 +145,6 @@ contract MarketplaceTest is BaseTest {
     }
 
     function test_closeAuctionForCreator_afterBuyout() public {
-        
         vm.deal(getActor(0), 100 ether);
         vm.deal(getActor(1), 100 ether);
 
@@ -178,12 +177,12 @@ contract MarketplaceTest is BaseTest {
          *  Auction is closed for the auction creator i.e. Actor-0. Outcome:
          *      - Actor-0 receives the escrowed buyout amount.
          */
-        
+
         uint256 listerBalBefore = getActor(0).balance;
 
         vm.warp(2);
         marketplace.closeAuction(listingId, getActor(0));
-        
+
         uint256 listerBalAfter = getActor(0).balance;
         uint256 winningBidPostFee = (5 ether * (MAX_BPS - platformFeeBps)) / MAX_BPS;
 

--- a/src/test/utils/BaseTest.sol
+++ b/src/test/utils/BaseTest.sol
@@ -36,12 +36,12 @@ abstract contract BaseTest is DSTest, stdCheats {
     MockERC20 public erc20;
     MockERC721 public erc721;
     MockERC1155 public erc1155;
+    WETH9 public weth;
 
     address public forwarder;
     address public registry;
     address public factory;
     address public fee;
-    address public weth;
 
     address public factoryAdmin = address(0x10000);
     address public deployer = address(0x20000);
@@ -50,6 +50,7 @@ abstract contract BaseTest is DSTest, stdCheats {
     address public platformFeeRecipient = address(0x30002);
     uint128 public royaltyBps = 500; // 5%
     uint128 public platformFeeBps = 500; // 5%
+    uint256 public constant MAX_BPS = 10_000; // 100%
 
     mapping(bytes32 => address) public contracts;
 
@@ -59,7 +60,7 @@ abstract contract BaseTest is DSTest, stdCheats {
         erc20 = new MockERC20();
         erc721 = new MockERC721();
         erc1155 = new MockERC1155();
-        weth = address(new WETH9());
+        weth = new WETH9();
         forwarder = address(new Forwarder());
         registry = address(new TWRegistry(forwarder));
         factory = address(new TWFactory(forwarder, registry));
@@ -71,7 +72,7 @@ abstract contract BaseTest is DSTest, stdCheats {
         TWFactory(factory).addImplementation(address(new DropERC20(fee)));
         TWFactory(factory).addImplementation(address(new DropERC721(fee)));
         TWFactory(factory).addImplementation(address(new DropERC1155(fee)));
-        TWFactory(factory).addImplementation(address(new Marketplace(weth, fee)));
+        TWFactory(factory).addImplementation(address(new Marketplace(address(weth), fee)));
         TWFactory(factory).addImplementation(address(new Split(fee)));
         // TWFactory(factory).addImplementation(address(new Pack(address(0), address(0), fee)));
         TWFactory(factory).addImplementation(address(new Multiwrap()));


### PR DESCRIPTION
Closes https://github.com/thirdweb-dev/contracts/issues/137.

## Bug fix

Changes in the contract's `handleBid` function address the bug reported in https://github.com/thirdweb-dev/contracts/issues/137. 

The contract now collects the incoming bid in both cases: when a bid is a buyout bid, and when a bid is a regular (winning) bid ([code](https://github.com/thirdweb-dev/contracts/blob/auction-buyout-fix/contracts/marketplace/Marketplace.sol#L539-L546)).

The fixed behaviour is tested in the test [`test_closeAuctionForCreator_afterBuyout`](https://github.com/thirdweb-dev/contracts/blob/auction-buyout-fix/src/test/Marketplace.sol#L147) in the file `src/test/Marketplace.sol`. Run the test by cloning the branch and running the command `forge test --match-contract Marketplace`.