### PR TITLE
Drop erc20 cleanup

### DIFF
--- a/contracts/drop/DropERC20.sol
+++ b/contracts/drop/DropERC20.sol
@@ -332,6 +332,11 @@ contract DropERC20 is
         emit ClaimConditionsUpdated(_phases);
     }
 
+    /// @dev Returns the claim condition at the given uid.
+    function getClaimConditionById(uint256 _conditionId) external view returns (ClaimCondition memory condition) {
+        condition = claimCondition.phases[_conditionId];
+    }
+
     //      =====   Setter functions  =====
 
     /// @dev Lets a module admin set a claim limit on a wallet.

--- a/contracts/drop/DropERC20.sol
+++ b/contracts/drop/DropERC20.sol
@@ -401,7 +401,7 @@ contract DropERC20 is
             return;
         }
 
-        uint256 totalPrice = _quantityToClaim * _pricePerToken;
+        uint256 totalPrice = (_quantityToClaim * _pricePerToken) / 1 ether;
         uint256 platformFees = (totalPrice * platformFeeBps) / MAX_BPS;
         (address twFeeRecipient, uint256 twFeeBps) = thirdwebFee.getFeeInfo(address(this), FeeType.PRIMARY_SALE);
         uint256 twFee = (totalPrice * twFeeBps) / MAX_BPS;

--- a/contracts/drop/DropERC20.sol
+++ b/contracts/drop/DropERC20.sol
@@ -1,80 +1,91 @@
 // SPDX-License-Identifier: Apache-2.0
 pragma solidity ^0.8.11;
 
-// Interface
-import { IDropERC20 } from "../interfaces/drop/IDropERC20.sol";
+//  ==========  External imports    ==========
 
-// Token
 import "@openzeppelin/contracts-upgradeable/token/ERC20/extensions/ERC20BurnableUpgradeable.sol";
 import "@openzeppelin/contracts-upgradeable/token/ERC20/extensions/ERC20PausableUpgradeable.sol";
 import "@openzeppelin/contracts-upgradeable/token/ERC20/extensions/ERC20VotesUpgradeable.sol";
 
-// Security
 import "@openzeppelin/contracts-upgradeable/access/AccessControlEnumerableUpgradeable.sol";
 import "@openzeppelin/contracts-upgradeable/security/ReentrancyGuardUpgradeable.sol";
 
-// Meta transactions
-import "../openzeppelin-presets/metatx/ERC2771ContextUpgradeable.sol";
-
-// Utils
 import "@openzeppelin/contracts-upgradeable/utils/structs/BitMapsUpgradeable.sol";
 import "@openzeppelin/contracts-upgradeable/utils/MulticallUpgradeable.sol";
+
+//  ==========  Internal imports    ==========
+
+import { IDropERC20 } from "../interfaces/drop/IDropERC20.sol";
+import { ITWFee } from "../interfaces/ITWFee.sol";
+
+import "../openzeppelin-presets/metatx/ERC2771ContextUpgradeable.sol";
+
 import "../lib/MerkleProof.sol";
 import "../lib/CurrencyTransferLib.sol";
 import "../lib/FeeType.sol";
-
-// Thirdweb top-level
-import "../interfaces/ITWFee.sol";
 
 contract DropERC20 is
     Initializable,
     ReentrancyGuardUpgradeable,
     ERC2771ContextUpgradeable,
     MulticallUpgradeable,
+    AccessControlEnumerableUpgradeable,
     ERC20BurnableUpgradeable,
     ERC20PausableUpgradeable,
     ERC20VotesUpgradeable,
-    IDropERC20,
-    AccessControlEnumerableUpgradeable
+    IDropERC20
 {
     using BitMapsUpgradeable for BitMapsUpgradeable.BitMap;
+
+    /*///////////////////////////////////////////////////////////////
+                            State variables
+    //////////////////////////////////////////////////////////////*/
 
     bytes32 private constant MODULE_TYPE = bytes32("DropERC20");
     uint128 private constant VERSION = 1;
 
-    bytes32 internal constant MINTER_ROLE = keccak256("MINTER_ROLE");
+    /// @dev Only transfers to or from TRANSFER_ROLE holders are valid, when transfers are restricted.
+    bytes32 private constant TRANSFER_ROLE = keccak256("TRANSFER_ROLE");
+    /// @dev Only PAUSER_ROLE holders can pause ERC20 token transfers.
     bytes32 internal constant PAUSER_ROLE = keccak256("PAUSER_ROLE");
-    bytes32 internal constant TRANSFER_ROLE = keccak256("TRANSFER_ROLE");
 
     /// @dev The thirdweb contract with fee related information.
     ITWFee internal immutable thirdwebFee;
 
-    /// @dev Returns the URI for the storefront-level metadata of the contract.
+    /// @dev Contract level metadata.
     string public contractURI;
 
-    /// @dev Max bps in the thirdweb system
+    /// @dev Max bps in the thirdweb system.
     uint128 internal constant MAX_BPS = 10_000;
 
-    /// @dev The % of primary sales collected by the contract as fees.
+    /// @dev The % of primary sales collected as platform fees.
     uint128 internal platformFeeBps;
 
-    /// @dev The adress that receives all primary sales value.
+    /// @dev The address that receives all platform fees from all sales.
     address internal platformFeeRecipient;
 
-    /// @dev The adress that receives all primary sales value.
+    /// @dev The address that receives all primary sales value.
     address public primarySaleRecipient;
 
-    /// @dev The max number of claim per wallet.
+    /// @dev The max number of tokens a wallet can claim.
     uint256 public maxWalletClaimCount;
 
-    /// @dev Token max total supply for the collection.
+    /// @dev Global max total supply of tokens.
     uint256 public maxTotalSupply;
 
-    /// @dev The claim conditions at any given moment.
+    /// @dev The set of all claim conditions, at any given moment.
     ClaimConditionList public claimCondition;
+
+    /*///////////////////////////////////////////////////////////////
+                                Mappings
+    //////////////////////////////////////////////////////////////*/
 
     /// @dev Mapping from address => number of tokens a wallet has claimed.
     mapping(address => uint256) public walletClaimCount;
+
+    /*///////////////////////////////////////////////////////////////
+                    Constructor + initializer logic
+    //////////////////////////////////////////////////////////////*/
 
     constructor(address _thirdwebFee) initializer {
         thirdwebFee = ITWFee(_thirdwebFee);
@@ -96,6 +107,7 @@ contract DropERC20 is
         __ERC20Permit_init(_name);
         __ERC20_init_unchained(_name, _symbol);
 
+        // Initialize this contract's state.
         contractURI = _contractURI;
         primarySaleRecipient = _primarySaleRecipient;
         platformFeeRecipient = _platformFeeRecipient;
@@ -103,15 +115,15 @@ contract DropERC20 is
 
         _setupRole(DEFAULT_ADMIN_ROLE, _defaultAdmin);
         _setupRole(TRANSFER_ROLE, _defaultAdmin);
-        _setupRole(MINTER_ROLE, _defaultAdmin);
         _setupRole(PAUSER_ROLE, _defaultAdmin);
-
         _setupRole(TRANSFER_ROLE, address(0));
     }
 
-    //      =====   Public functions  =====
+    /*///////////////////////////////////////////////////////////////
+                        Generic contract logic
+    //////////////////////////////////////////////////////////////*/
 
-    /// @dev Returns the module type of the contract.
+    /// @dev Returns the type of the contract.
     function contractType() external pure returns (bytes32) {
         return MODULE_TYPE;
     }
@@ -119,6 +131,21 @@ contract DropERC20 is
     /// @dev Returns the version of the contract.
     function contractVersion() external pure returns (uint8) {
         return uint8(VERSION);
+    }
+
+    /*///////////////////////////////////////////////////////////////
+                    ERC 165 + ERC20 transfer hooks
+    //////////////////////////////////////////////////////////////*/
+
+    /// @dev See ERC 165
+    function supportsInterface(bytes4 interfaceId)
+        public
+        view
+        virtual
+        override(AccessControlEnumerableUpgradeable)
+        returns (bool)
+    {
+        return super.supportsInterface(interfaceId);
     }
 
     function _afterTokenTransfer(
@@ -142,100 +169,11 @@ contract DropERC20 is
         }
     }
 
-    /// @dev At any given moment, returns the uid for the active claim condition.
-    function getActiveClaimConditionId() public view returns (uint256) {
-        for (uint256 i = claimCondition.currentStartId + claimCondition.count; i > claimCondition.currentStartId; i--) {
-            if (block.timestamp >= claimCondition.phases[i - 1].startTimestamp) {
-                return i - 1;
-            }
-        }
+    /*///////////////////////////////////////////////////////////////
+                            Claim logic
+    //////////////////////////////////////////////////////////////*/
 
-        revert("no active mint condition.");
-    }
-
-    /// @dev Returns the timestamp for next available claim for a claimer address
-    function getClaimTimestamp(uint256 _conditionId, address _claimer)
-        public
-        view
-        returns (uint256 lastClaimTimestamp, uint256 nextValidClaimTimestamp)
-    {
-        lastClaimTimestamp = claimCondition.limitLastClaimTimestamp[_conditionId][_claimer];
-
-        unchecked {
-            nextValidClaimTimestamp =
-                lastClaimTimestamp +
-                claimCondition.phases[_conditionId].waitTimeInSecondsBetweenClaims;
-
-            if (nextValidClaimTimestamp < lastClaimTimestamp) {
-                nextValidClaimTimestamp = type(uint256).max;
-            }
-        }
-    }
-
-    /// @dev Returns the platform fee bps and recipient.
-    function getPlatformFeeInfo() external view returns (address, uint16) {
-        return (platformFeeRecipient, uint16(platformFeeBps));
-    }
-
-    /// @dev Checks whether a request to claim tokens obeys the active mint condition.
-    function verifyClaim(
-        uint256 _conditionId,
-        address _claimer,
-        uint256 _quantity,
-        address _currency,
-        uint256 _pricePerToken
-    ) public view {
-        ClaimCondition memory currentClaimPhase = claimCondition.phases[_conditionId];
-
-        require(
-            _currency == currentClaimPhase.currency && _pricePerToken == currentClaimPhase.pricePerToken,
-            "invalid currency or price specified."
-        );
-        require(
-            _quantity > 0 && _quantity <= currentClaimPhase.quantityLimitPerTransaction,
-            "invalid quantity claimed."
-        );
-        require(
-            currentClaimPhase.supplyClaimed + _quantity <= currentClaimPhase.maxClaimableSupply,
-            "exceed max mint supply."
-        );
-        require(maxTotalSupply == 0 || totalSupply() + _quantity <= maxTotalSupply, "exceed max total supply.");
-        require(
-            maxWalletClaimCount == 0 || walletClaimCount[_claimer] + _quantity <= maxWalletClaimCount,
-            "exceed claim limit for wallet"
-        );
-
-        (uint256 lastClaimTimestamp, uint256 nextValidClaimTimestamp) = getClaimTimestamp(_conditionId, _claimer);
-        require(lastClaimTimestamp == 0 || block.timestamp >= nextValidClaimTimestamp, "cannot claim yet.");
-    }
-
-    function verifyClaimMerkleProof(
-        uint256 _conditionId,
-        address _claimer,
-        uint256 _quantity,
-        bytes32[] calldata _proofs,
-        uint256 _proofMaxQuantityPerTransaction
-    ) public view returns (bool validMerkleProof, uint256 merkleProofIndex) {
-        ClaimCondition memory currentClaimPhase = claimCondition.phases[_conditionId];
-
-        if (currentClaimPhase.merkleRoot != bytes32(0)) {
-            (validMerkleProof, merkleProofIndex) = MerkleProof.verify(
-                _proofs,
-                currentClaimPhase.merkleRoot,
-                keccak256(abi.encodePacked(_claimer, _proofMaxQuantityPerTransaction))
-            );
-            require(validMerkleProof, "not in whitelist.");
-            require(!claimCondition.limitMerkleProofClaim[_conditionId].get(merkleProofIndex), "proof claimed.");
-            require(
-                _proofMaxQuantityPerTransaction == 0 || _quantity <= _proofMaxQuantityPerTransaction,
-                "invalid quantity proof."
-            );
-        }
-    }
-
-    //      =====   External functions  =====
-
-    /// @dev Lets an account claim a given quantity of tokens, of a single tokenId, according to claim conditions.
+    /// @dev Lets an account claim tokens.
     function claim(
         address _receiver,
         uint256 _quantity,
@@ -250,6 +188,7 @@ contract DropERC20 is
         // Verify claim validity. If not valid, revert.
         verifyClaim(activeConditionId, _msgSender(), _quantity, _currency, _pricePerToken);
 
+        // Verify inclusion in allowlist
         (bool validMerkleProof, uint256 merkleProofIndex) = verifyClaimMerkleProof(
             activeConditionId,
             _msgSender(),
@@ -258,10 +197,8 @@ contract DropERC20 is
             _proofMaxQuantityPerTransaction
         );
 
-        // if the current claim condition and has a merkle root and the provided proof is valid
-        // if validMerkleProof is false, it means that claim condition does not have a merkle root
-        // if invalid proofs are provided, the verifyClaimMerkleProof would revert.
         if (validMerkleProof && _proofMaxQuantityPerTransaction > 0) {
+            // Mark the claimer's use of their position in the allowlist.
             claimCondition.limitMerkleProofClaim[activeConditionId].set(merkleProofIndex);
         }
 
@@ -274,24 +211,32 @@ contract DropERC20 is
         emit TokensClaimed(activeConditionId, _msgSender(), _receiver, _quantity);
     }
 
-    /// @dev Lets a module admin set claim conditions.
-    function setClaimConditions(ClaimCondition[] calldata _phases, bool _resetLimitRestriction)
+    /// @dev Lets a contract admin (account with `DEFAULT_ADMIN_ROLE`) set claim conditions.
+    function setClaimConditions(ClaimCondition[] calldata _phases, bool _resetClaimEligibility)
         external
         onlyRole(DEFAULT_ADMIN_ROLE)
     {
         uint256 existingStartIndex = claimCondition.currentStartId;
         uint256 existingPhaseCount = claimCondition.count;
 
-        // if it's to reset restriction, all new claim phases would start at the end of the existing batch.
-        // otherwise, the new claim phases would override the existing phases and limits from the existing start index
+        /**
+         *  `limitLastClaimTimestamp` and `limitMerkleProofClaim` are mappings that use a
+         *  claim condition's UID as a key.
+         *
+         *  If `_resetClaimEligibility == true`, we assign completely new UIDs to the claim
+         *  conditions in `_phases`, effectively resetting the restrictions on claims expressed
+         *  by `limitLastClaimTimestamp` and `limitMerkleProofClaim`.
+         */
         uint256 newStartIndex = existingStartIndex;
-        if (_resetLimitRestriction) {
+        if (_resetClaimEligibility) {
             newStartIndex = existingStartIndex + existingPhaseCount;
         }
 
+        claimCondition.count = _phases.length;
+        claimCondition.currentStartId = newStartIndex;
+
         uint256 lastConditionStartTimestamp;
         for (uint256 i = 0; i < _phases.length; i++) {
-            // only compare the 2nd++ phase start timestamp to the previous start timestamp
             require(
                 i == 0 || lastConditionStartTimestamp < _phases[i].startTimestamp,
                 "startTimestamp must be in ascending order."
@@ -303,21 +248,22 @@ contract DropERC20 is
             lastConditionStartTimestamp = _phases[i].startTimestamp;
         }
 
-        // freeing up claim phases and claim limit (gas refund)
-        // if we are resetting restriction, then we'd clean up previous batch map up to the new start index.
-        // if we are not, it means that we're updating, then we'd only clean up unused claim phases and limits.
-        // not deleting last claim timestamp maps because we don't have access to addresses. it's fine to not clean it up
-        // because the currentStartId decides which claim timestamp map to use.
-        if (_resetLimitRestriction) {
+        /**
+         *  Gas refunds (as much as possible)
+         *
+         *  If `_resetClaimEligibility == true`, we assign completely new UIDs to the claim
+         *  conditions in `_phases`. So, we delete claim conditions with UID < `newStartIndex`.
+         *
+         *  If `_resetClaimEligibility == false`, and there are more existing claim conditions
+         *  than in `_phases`, we delete the existing claim conditions that don't get replaced
+         *  by the conditions in `_phases`.
+         */
+        if (_resetClaimEligibility) {
             for (uint256 i = existingStartIndex; i < newStartIndex; i++) {
                 delete claimCondition.phases[i];
                 delete claimCondition.limitMerkleProofClaim[i];
             }
         } else {
-            // in the update scenario:
-            // if there are more old (existing) phases than the newly set ones, delete all the remaining
-            // unused phases and limits.
-            // if there are more new phases than old phases, then there's no excess claim condition to clean up.
             if (existingPhaseCount > _phases.length) {
                 for (uint256 i = _phases.length; i < existingPhaseCount; i++) {
                     delete claimCondition.phases[newStartIndex + i];
@@ -326,69 +272,7 @@ contract DropERC20 is
             }
         }
 
-        claimCondition.count = _phases.length;
-        claimCondition.currentStartId = newStartIndex;
-
         emit ClaimConditionsUpdated(_phases);
-    }
-
-    /// @dev Returns the claim condition at the given uid.
-    function getClaimConditionById(uint256 _conditionId) external view returns (ClaimCondition memory condition) {
-        condition = claimCondition.phases[_conditionId];
-    }
-
-    //      =====   Setter functions  =====
-
-    /// @dev Lets a module admin set a claim limit on a wallet.
-    function setWalletClaimCount(address _claimer, uint256 _count) external onlyRole(DEFAULT_ADMIN_ROLE) {
-        walletClaimCount[_claimer] = _count;
-        emit WalletClaimCountUpdated(_claimer, _count);
-    }
-
-    /// @dev Lets a module admin set a maximum number of claim per wallet.
-    function setMaxWalletClaimCount(uint256 _count) external onlyRole(DEFAULT_ADMIN_ROLE) {
-        maxWalletClaimCount = _count;
-        emit MaxWalletClaimCountUpdated(_count);
-    }
-
-    /// @dev Lets a module admin set the maximum number of supply for the collection.
-    function setMaxTotalSupply(uint256 _maxTotalSupply) external onlyRole(DEFAULT_ADMIN_ROLE) {
-        maxTotalSupply = _maxTotalSupply;
-        emit MaxTotalSupplyUpdated(_maxTotalSupply);
-    }
-
-    /// @dev Lets a module admin set the default recipient of all primary sales.
-    function setPrimarySaleRecipient(address _saleRecipient) external onlyRole(DEFAULT_ADMIN_ROLE) {
-        primarySaleRecipient = _saleRecipient;
-        emit PrimarySaleRecipientUpdated(_saleRecipient);
-    }
-
-    /// @dev Lets a module admin update the fees on primary sales.
-    function setPlatformFeeInfo(address _platformFeeRecipient, uint256 _platformFeeBps)
-        external
-        onlyRole(DEFAULT_ADMIN_ROLE)
-    {
-        require(_platformFeeBps <= MAX_BPS, "bps <= 10000.");
-
-        platformFeeBps = uint64(_platformFeeBps);
-        platformFeeRecipient = _platformFeeRecipient;
-
-        emit PlatformFeeInfoUpdated(_platformFeeRecipient, _platformFeeBps);
-    }
-
-    /// @dev Lets a module admin set the URI for contract-level metadata.
-    function setContractURI(string calldata _uri) external onlyRole(DEFAULT_ADMIN_ROLE) {
-        contractURI = _uri;
-    }
-
-    //      =====   Internal functions  =====
-
-    function _mint(address account, uint256 amount) internal virtual override(ERC20Upgradeable, ERC20VotesUpgradeable) {
-        super._mint(account, amount);
-    }
-
-    function _burn(address account, uint256 amount) internal virtual override(ERC20Upgradeable, ERC20VotesUpgradeable) {
-        super._burn(account, amount);
     }
 
     /// @dev Collects and distributes the primary sale value of tokens being claimed.
@@ -401,6 +285,7 @@ contract DropERC20 is
             return;
         }
 
+        // `_pricePerToken` is interpreted as price per 1 ether unit of the ERC20 tokens.
         uint256 totalPrice = (_quantityToClaim * _pricePerToken) / 1 ether;
         uint256 platformFees = (totalPrice * platformFeeBps) / MAX_BPS;
         (address twFeeRecipient, uint256 twFeeBps) = thirdwebFee.getFeeInfo(address(this), FeeType.PRIMARY_SALE);
@@ -432,22 +317,169 @@ contract DropERC20 is
         // if transfer claimed tokens is called when to != msg.sender, it'd use msg.sender's limits.
         // behavior would be similar to msg.sender mint for itself, then transfer to `to`.
         claimCondition.limitLastClaimTimestamp[_conditionId][_msgSender()] = block.timestamp;
-
-        // wallet count limit is global, not scoped to the phases
         walletClaimCount[_msgSender()] += _quantityBeingClaimed;
 
         _mint(_to, _quantityBeingClaimed);
     }
 
-    /// @dev See ERC 165
-    function supportsInterface(bytes4 interfaceId)
+    /// @dev Checks a request to claim tokens against the active claim condition's criteria.
+    function verifyClaim(
+        uint256 _conditionId,
+        address _claimer,
+        uint256 _quantity,
+        address _currency,
+        uint256 _pricePerToken
+    ) public view {
+        ClaimCondition memory currentClaimPhase = claimCondition.phases[_conditionId];
+
+        require(
+            _currency == currentClaimPhase.currency && _pricePerToken == currentClaimPhase.pricePerToken,
+            "invalid currency or price specified."
+        );
+        require(
+            _quantity > 0 && _quantity <= currentClaimPhase.quantityLimitPerTransaction,
+            "invalid quantity claimed."
+        );
+        require(
+            currentClaimPhase.supplyClaimed + _quantity <= currentClaimPhase.maxClaimableSupply,
+            "exceed max mint supply."
+        );
+        require(maxTotalSupply == 0 || totalSupply() + _quantity <= maxTotalSupply, "exceed max total supply.");
+        require(
+            maxWalletClaimCount == 0 || walletClaimCount[_claimer] + _quantity <= maxWalletClaimCount,
+            "exceed claim limit for wallet"
+        );
+
+        (uint256 lastClaimTimestamp, uint256 nextValidClaimTimestamp) = getClaimTimestamp(_conditionId, _claimer);
+        require(lastClaimTimestamp == 0 || block.timestamp >= nextValidClaimTimestamp, "cannot claim yet.");
+    }
+
+    /// @dev Checks whether a claimer meets the claim condition's allowlist criteria.
+    function verifyClaimMerkleProof(
+        uint256 _conditionId,
+        address _claimer,
+        uint256 _quantity,
+        bytes32[] calldata _proofs,
+        uint256 _proofMaxQuantityPerTransaction
+    ) public view returns (bool validMerkleProof, uint256 merkleProofIndex) {
+        ClaimCondition memory currentClaimPhase = claimCondition.phases[_conditionId];
+
+        if (currentClaimPhase.merkleRoot != bytes32(0)) {
+            (validMerkleProof, merkleProofIndex) = MerkleProof.verify(
+                _proofs,
+                currentClaimPhase.merkleRoot,
+                keccak256(abi.encodePacked(_claimer, _proofMaxQuantityPerTransaction))
+            );
+            require(validMerkleProof, "not in whitelist.");
+            require(!claimCondition.limitMerkleProofClaim[_conditionId].get(merkleProofIndex), "proof claimed.");
+            require(
+                _proofMaxQuantityPerTransaction == 0 || _quantity <= _proofMaxQuantityPerTransaction,
+                "invalid quantity proof."
+            );
+        }
+    }
+
+    /*///////////////////////////////////////////////////////////////
+                        Getter functions
+    //////////////////////////////////////////////////////////////*/
+
+    /// @dev At any given moment, returns the uid for the active claim condition.
+    function getActiveClaimConditionId() public view returns (uint256) {
+        for (uint256 i = claimCondition.currentStartId + claimCondition.count; i > claimCondition.currentStartId; i--) {
+            if (block.timestamp >= claimCondition.phases[i - 1].startTimestamp) {
+                return i - 1;
+            }
+        }
+
+        revert("no active mint condition.");
+    }
+
+    /// @dev Returns the timestamp for when a claimer is eligible for claiming tokens again.
+    function getClaimTimestamp(uint256 _conditionId, address _claimer)
         public
         view
-        virtual
-        override(AccessControlEnumerableUpgradeable)
-        returns (bool)
+        returns (uint256 lastClaimTimestamp, uint256 nextValidClaimTimestamp)
     {
-        return super.supportsInterface(interfaceId);
+        lastClaimTimestamp = claimCondition.limitLastClaimTimestamp[_conditionId][_claimer];
+
+        unchecked {
+            nextValidClaimTimestamp =
+                lastClaimTimestamp +
+                claimCondition.phases[_conditionId].waitTimeInSecondsBetweenClaims;
+
+            if (nextValidClaimTimestamp < lastClaimTimestamp) {
+                nextValidClaimTimestamp = type(uint256).max;
+            }
+        }
+    }
+
+    /// @dev Returns the claim condition at the given uid.
+    function getClaimConditionById(uint256 _conditionId) external view returns (ClaimCondition memory condition) {
+        condition = claimCondition.phases[_conditionId];
+    }
+
+    /// @dev Returns the platform fee recipient and bps.
+    function getPlatformFeeInfo() external view returns (address, uint16) {
+        return (platformFeeRecipient, uint16(platformFeeBps));
+    }
+
+    /*///////////////////////////////////////////////////////////////
+                        Setter functions
+    //////////////////////////////////////////////////////////////*/
+
+    /// @dev Lets a contract admin set a claim count for a wallet.
+    function setWalletClaimCount(address _claimer, uint256 _count) external onlyRole(DEFAULT_ADMIN_ROLE) {
+        walletClaimCount[_claimer] = _count;
+        emit WalletClaimCountUpdated(_claimer, _count);
+    }
+
+    /// @dev Lets a contract admin set a maximum number of tokens that can be claimed by any wallet.
+    function setMaxWalletClaimCount(uint256 _count) external onlyRole(DEFAULT_ADMIN_ROLE) {
+        maxWalletClaimCount = _count;
+        emit MaxWalletClaimCountUpdated(_count);
+    }
+
+    /// @dev Lets a contract admin set the global maximum supply of tokens.
+    function setMaxTotalSupply(uint256 _maxTotalSupply) external onlyRole(DEFAULT_ADMIN_ROLE) {
+        require(_maxTotalSupply < totalSupply(), "already minted more than desired max supply");
+        maxTotalSupply = _maxTotalSupply;
+        emit MaxTotalSupplyUpdated(_maxTotalSupply);
+    }
+
+    /// @dev Lets a contract admin set the recipient for all primary sales.
+    function setPrimarySaleRecipient(address _saleRecipient) external onlyRole(DEFAULT_ADMIN_ROLE) {
+        primarySaleRecipient = _saleRecipient;
+        emit PrimarySaleRecipientUpdated(_saleRecipient);
+    }
+
+    /// @dev Lets a contract admin update the platform fee recipient and bps
+    function setPlatformFeeInfo(address _platformFeeRecipient, uint256 _platformFeeBps)
+        external
+        onlyRole(DEFAULT_ADMIN_ROLE)
+    {
+        require(_platformFeeBps <= MAX_BPS, "bps <= 10000.");
+
+        platformFeeBps = uint64(_platformFeeBps);
+        platformFeeRecipient = _platformFeeRecipient;
+
+        emit PlatformFeeInfoUpdated(_platformFeeRecipient, _platformFeeBps);
+    }
+
+    /// @dev Lets a contract admin set the URI for contract-level metadata.
+    function setContractURI(string calldata _uri) external onlyRole(DEFAULT_ADMIN_ROLE) {
+        contractURI = _uri;
+    }
+
+    /*///////////////////////////////////////////////////////////////
+                            Miscellaneous
+    //////////////////////////////////////////////////////////////*/
+
+    function _mint(address account, uint256 amount) internal virtual override(ERC20Upgradeable, ERC20VotesUpgradeable) {
+        super._mint(account, amount);
+    }
+
+    function _burn(address account, uint256 amount) internal virtual override(ERC20Upgradeable, ERC20VotesUpgradeable) {
+        super._burn(account, amount);
     }
 
     function _msgSender()

--- a/contracts/drop/DropERC20.sol
+++ b/contracts/drop/DropERC20.sol
@@ -31,7 +31,6 @@ contract DropERC20 is
     MulticallUpgradeable,
     AccessControlEnumerableUpgradeable,
     ERC20BurnableUpgradeable,
-    ERC20PausableUpgradeable,
     ERC20VotesUpgradeable,
     IDropERC20
 {
@@ -46,8 +45,6 @@ contract DropERC20 is
 
     /// @dev Only transfers to or from TRANSFER_ROLE holders are valid, when transfers are restricted.
     bytes32 private constant TRANSFER_ROLE = keccak256("TRANSFER_ROLE");
-    /// @dev Only PAUSER_ROLE holders can pause ERC20 token transfers.
-    bytes32 internal constant PAUSER_ROLE = keccak256("PAUSER_ROLE");
 
     /// @dev The thirdweb contract with fee related information.
     ITWFee internal immutable thirdwebFee;
@@ -115,7 +112,6 @@ contract DropERC20 is
 
         _setupRole(DEFAULT_ADMIN_ROLE, _defaultAdmin);
         _setupRole(TRANSFER_ROLE, _defaultAdmin);
-        _setupRole(PAUSER_ROLE, _defaultAdmin);
         _setupRole(TRANSFER_ROLE, address(0));
     }
 
@@ -161,7 +157,7 @@ contract DropERC20 is
         address from,
         address to,
         uint256 amount
-    ) internal override(ERC20Upgradeable, ERC20PausableUpgradeable) {
+    ) internal override(ERC20Upgradeable) {
         super._beforeTokenTransfer(from, to, amount);
 
         if (!hasRole(TRANSFER_ROLE, address(0)) && from != address(0) && to != address(0)) {

--- a/contracts/interfaces/drop/IDropERC20.sol
+++ b/contracts/interfaces/drop/IDropERC20.sol
@@ -8,11 +8,12 @@ import "../IThirdwebPrimarySale.sol";
 import "./IDropClaimCondition.sol";
 
 /**
- *  `LazyMintERC20` is an ERC 20 contract.
+ *  Thirdweb's 'Drop' contracts are distribution mechanisms for tokens. The
+ *  `DropERC20` contract is a distribution mechanism for ERC20 tokens.
  *
- *  The module admin can create claim conditions with non-overlapping time windows,
- *  and accounts can claim the tokens, in a given time window, according to restrictions
- *  defined in that time window's claim conditions.
+ *  A contract admin (i.e. holder of `DEFAULT_ADMIN_ROLE`) can create claim conditions
+ *  with non-overlapping time windows, and accounts can claim the tokens according to
+ *  restrictions defined in the claim condition that is active at the time of the transaction.
  */
 
 interface IDropERC20 is
@@ -33,46 +34,50 @@ interface IDropERC20 is
     /// @dev Emitted when new claim conditions are set.
     event ClaimConditionsUpdated(ClaimCondition[] claimConditions);
 
-    /// @dev Emitted when a new sale recipient is set.
+    /// @dev Emitted when a new primary sale recipient is set.
     event PrimarySaleRecipientUpdated(address indexed recipient);
 
-    /// @dev Emitted when fee on primary sales is updated.
+    /// @dev Emitted when fee platform fee recipient or bps is updated.
     event PlatformFeeInfoUpdated(address platformFeeRecipient, uint256 platformFeeBps);
 
-    /// @dev Emitted when a max total supply is set for a token.
+    /// @dev Emitted when the global max supply of tokens is updated.
     event MaxTotalSupplyUpdated(uint256 maxTotalSupply);
 
-    /// @dev Emitted when a wallet claim count is updated.
+    /// @dev Emitted when the wallet claim count for an address is updated.
     event WalletClaimCountUpdated(address indexed wallet, uint256 count);
 
-    /// @dev Emitted when the max wallet claim count is updated.
+    /// @dev Emitted when the global max wallet claim count is updated.
     event MaxWalletClaimCountUpdated(uint256 count);
 
     /**
      *  @notice Lets an account claim a given quantity of tokens.
      *
-     *  @param _receiver The receiver of the NFTs to claim.
-     *  @param _quantity The quantity of tokens to claim.
-     *  @param _currency The currency in which to pay for the claim.
-     *  @param _pricePerToken The price per token to pay for the claim.
-     *  @param _proofs The proof required to prove the account's inclusion in the merkle root whitelist
-     *                 of the mint conditions that apply.
-     *  @param _proofMaxQuantityPerTransaction The maximum claim quantity per transactions that included in the merkle proof.
+     *  @param receiver                       The receiver of the tokens to claim.
+     *  @param quantity                       The quantity of tokens to claim.
+     *  @param currency                       The currency in which to pay for the claim.
+     *  @param pricePerToken                  The price per token (i.e. price per 1 ether unit of the token)
+     *                                         to pay for the claim.
+     *  @param proofs                         The proof of the claimer's inclusion in the merkle root allowlist
+     *                                        of the claim conditions that apply.
+     *  @param proofMaxQuantityPerTransaction (Optional) The maximum number of tokens an address included in an
+     *                                        allowlist can claim.
      */
     function claim(
-        address _receiver,
-        uint256 _quantity,
-        address _currency,
-        uint256 _pricePerToken,
-        bytes32[] calldata _proofs,
-        uint256 _proofMaxQuantityPerTransaction
+        address receiver,
+        uint256 quantity,
+        address currency,
+        uint256 pricePerToken,
+        bytes32[] calldata proofs,
+        uint256 proofMaxQuantityPerTransaction
     ) external payable;
 
     /**
-     *  @notice Lets a module admin (account with `DEFAULT_ADMIN_ROLE`) set claim conditions.
+     *  @notice Lets a contract admin (account with `DEFAULT_ADMIN_ROLE`) set claim conditions.
      *
-     *  @param _phases Mint conditions in ascending order by `startTimestamp`.
-     *  @param _resetLimitRestriction To reset claim phases limit restriction.
+     *  @param phases                Claim conditions in ascending order by `startTimestamp`.
+     *  @param resetClaimEligibility Whether to reset `limitLastClaimTimestamp` and
+     *                               `limitMerkleProofClaim` values when setting new
+     *                               claim conditions.
      */
-    function setClaimConditions(ClaimCondition[] calldata _phases, bool _resetLimitRestriction) external;
+    function setClaimConditions(ClaimCondition[] calldata phases, bool resetClaimEligibility) external;
 }

--- a/docs/DropERC20.md
+++ b/docs/DropERC20.md
@@ -176,7 +176,7 @@ function claim(address _receiver, uint256 _quantity, address _currency, uint256 
 
 
 
-*Lets an account claim a given quantity of tokens, of a single tokenId, according to claim conditions.*
+*Lets an account claim tokens.*
 
 #### Parameters
 
@@ -197,7 +197,7 @@ function claimCondition() external view returns (uint256 currentStartId, uint256
 
 
 
-*The claim conditions at any given moment.*
+*The set of all claim conditions, at any given moment.*
 
 
 #### Returns
@@ -215,7 +215,7 @@ function contractType() external pure returns (bytes32)
 
 
 
-*Returns the module type of the contract.*
+*Returns the type of the contract.*
 
 
 #### Returns
@@ -232,7 +232,7 @@ function contractURI() external view returns (string)
 
 
 
-*Returns the URI for the storefront-level metadata of the contract.*
+*Contract level metadata.*
 
 
 #### Returns
@@ -374,6 +374,28 @@ function getActiveClaimConditionId() external view returns (uint256)
 |---|---|---|
 | _0 | uint256 | undefined
 
+### getClaimConditionById
+
+```solidity
+function getClaimConditionById(uint256 _conditionId) external view returns (struct IDropClaimCondition.ClaimCondition condition)
+```
+
+
+
+*Returns the claim condition at the given uid.*
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| _conditionId | uint256 | undefined
+
+#### Returns
+
+| Name | Type | Description |
+|---|---|---|
+| condition | IDropClaimCondition.ClaimCondition | undefined
+
 ### getClaimTimestamp
 
 ```solidity
@@ -382,7 +404,7 @@ function getClaimTimestamp(uint256 _conditionId, address _claimer) external view
 
 
 
-*Returns the timestamp for next available claim for a claimer address*
+*Returns the timestamp for when a claimer is eligible for claiming tokens again.*
 
 #### Parameters
 
@@ -451,7 +473,7 @@ function getPlatformFeeInfo() external view returns (address, uint16)
 
 
 
-*Returns the platform fee bps and recipient.*
+*Returns the platform fee recipient and bps.*
 
 
 #### Returns
@@ -666,7 +688,7 @@ function maxTotalSupply() external view returns (uint256)
 
 
 
-*Token max total supply for the collection.*
+*Global max total supply of tokens.*
 
 
 #### Returns
@@ -683,7 +705,7 @@ function maxWalletClaimCount() external view returns (uint256)
 
 
 
-*The max number of claim per wallet.*
+*The max number of tokens a wallet can claim.*
 
 
 #### Returns
@@ -822,7 +844,7 @@ function primarySaleRecipient() external view returns (address)
 
 
 
-*The adress that receives all primary sales value.*
+*The address that receives all primary sales value.*
 
 
 #### Returns
@@ -868,19 +890,19 @@ function revokeRole(bytes32 role, address account) external nonpayable
 ### setClaimConditions
 
 ```solidity
-function setClaimConditions(IDropClaimCondition.ClaimCondition[] _phases, bool _resetLimitRestriction) external nonpayable
+function setClaimConditions(IDropClaimCondition.ClaimCondition[] _phases, bool _resetClaimEligibility) external nonpayable
 ```
 
 
 
-*Lets a module admin set claim conditions.*
+*Lets a contract admin (account with `DEFAULT_ADMIN_ROLE`) set claim conditions.*
 
 #### Parameters
 
 | Name | Type | Description |
 |---|---|---|
 | _phases | IDropClaimCondition.ClaimCondition[] | undefined
-| _resetLimitRestriction | bool | undefined
+| _resetClaimEligibility | bool | undefined
 
 ### setContractURI
 
@@ -890,7 +912,7 @@ function setContractURI(string _uri) external nonpayable
 
 
 
-*Lets a module admin set the URI for contract-level metadata.*
+*Lets a contract admin set the URI for contract-level metadata.*
 
 #### Parameters
 
@@ -906,7 +928,7 @@ function setMaxTotalSupply(uint256 _maxTotalSupply) external nonpayable
 
 
 
-*Lets a module admin set the maximum number of supply for the collection.*
+*Lets a contract admin set the global maximum supply of tokens.*
 
 #### Parameters
 
@@ -922,7 +944,7 @@ function setMaxWalletClaimCount(uint256 _count) external nonpayable
 
 
 
-*Lets a module admin set a maximum number of claim per wallet.*
+*Lets a contract admin set a maximum number of tokens that can be claimed by any wallet.*
 
 #### Parameters
 
@@ -938,7 +960,7 @@ function setPlatformFeeInfo(address _platformFeeRecipient, uint256 _platformFeeB
 
 
 
-*Lets a module admin update the fees on primary sales.*
+*Lets a contract admin update the platform fee recipient and bps*
 
 #### Parameters
 
@@ -955,7 +977,7 @@ function setPrimarySaleRecipient(address _saleRecipient) external nonpayable
 
 
 
-*Lets a module admin set the default recipient of all primary sales.*
+*Lets a contract admin set the recipient for all primary sales.*
 
 #### Parameters
 
@@ -971,7 +993,7 @@ function setWalletClaimCount(address _claimer, uint256 _count) external nonpayab
 
 
 
-*Lets a module admin set a claim limit on a wallet.*
+*Lets a contract admin set a claim count for a wallet.*
 
 #### Parameters
 
@@ -1091,7 +1113,7 @@ function verifyClaim(uint256 _conditionId, address _claimer, uint256 _quantity, 
 
 
 
-*Checks whether a request to claim tokens obeys the active mint condition.*
+*Checks a request to claim tokens against the active claim condition&#39;s criteria.*
 
 #### Parameters
 
@@ -1111,7 +1133,7 @@ function verifyClaimMerkleProof(uint256 _conditionId, address _claimer, uint256 
 
 
 
-
+*Checks whether a claimer meets the claim condition&#39;s allowlist criteria.*
 
 #### Parameters
 

--- a/docs/IDropERC20.md
+++ b/docs/IDropERC20.md
@@ -4,7 +4,7 @@
 
 
 
-`LazyMintERC20` is an ERC 20 contract.  The module admin can create claim conditions with non-overlapping time windows,  and accounts can claim the tokens, in a given time window, according to restrictions  defined in that time window&#39;s claim conditions.
+Thirdweb&#39;s &#39;Drop&#39; contracts are distribution mechanisms for tokens. The  `DropERC20` contract is a distribution mechanism for ERC20 tokens.  A contract admin (i.e. holder of `DEFAULT_ADMIN_ROLE`) can create claim conditions  with non-overlapping time windows, and accounts can claim the tokens according to  restrictions defined in the claim condition that is active at the time of the transaction.
 
 
 
@@ -81,7 +81,7 @@ function balanceOf(address account) external view returns (uint256)
 ### claim
 
 ```solidity
-function claim(address _receiver, uint256 _quantity, address _currency, uint256 _pricePerToken, bytes32[] _proofs, uint256 _proofMaxQuantityPerTransaction) external payable
+function claim(address receiver, uint256 quantity, address currency, uint256 pricePerToken, bytes32[] proofs, uint256 proofMaxQuantityPerTransaction) external payable
 ```
 
 Lets an account claim a given quantity of tokens.
@@ -92,12 +92,12 @@ Lets an account claim a given quantity of tokens.
 
 | Name | Type | Description |
 |---|---|---|
-| _receiver | address | The receiver of the NFTs to claim.
-| _quantity | uint256 | The quantity of tokens to claim.
-| _currency | address | The currency in which to pay for the claim.
-| _pricePerToken | uint256 | The price per token to pay for the claim.
-| _proofs | bytes32[] | The proof required to prove the account&#39;s inclusion in the merkle root whitelist                 of the mint conditions that apply.
-| _proofMaxQuantityPerTransaction | uint256 | The maximum claim quantity per transactions that included in the merkle proof.
+| receiver | address | The receiver of the tokens to claim.
+| quantity | uint256 | The quantity of tokens to claim.
+| currency | address | The currency in which to pay for the claim.
+| pricePerToken | uint256 | The price per token (i.e. price per 1 ether unit of the token)                                         to pay for the claim.
+| proofs | bytes32[] | The proof of the claimer&#39;s inclusion in the merkle root allowlist                                        of the claim conditions that apply.
+| proofMaxQuantityPerTransaction | uint256 | (Optional) The maximum number of tokens an address included in an                                        allowlist can claim.
 
 ### contractType
 
@@ -188,10 +188,10 @@ function primarySaleRecipient() external view returns (address)
 ### setClaimConditions
 
 ```solidity
-function setClaimConditions(IDropClaimCondition.ClaimCondition[] _phases, bool _resetLimitRestriction) external nonpayable
+function setClaimConditions(IDropClaimCondition.ClaimCondition[] phases, bool resetClaimEligibility) external nonpayable
 ```
 
-Lets a module admin (account with `DEFAULT_ADMIN_ROLE`) set claim conditions.
+Lets a contract admin (account with `DEFAULT_ADMIN_ROLE`) set claim conditions.
 
 
 
@@ -199,8 +199,8 @@ Lets a module admin (account with `DEFAULT_ADMIN_ROLE`) set claim conditions.
 
 | Name | Type | Description |
 |---|---|---|
-| _phases | IDropClaimCondition.ClaimCondition[] | Mint conditions in ascending order by `startTimestamp`.
-| _resetLimitRestriction | bool | To reset claim phases limit restriction.
+| phases | IDropClaimCondition.ClaimCondition[] | Claim conditions in ascending order by `startTimestamp`.
+| resetClaimEligibility | bool | Whether to reset `limitLastClaimTimestamp` and                               `limitMerkleProofClaim` values when setting new                               claim conditions.
 
 ### setContractURI
 
@@ -361,7 +361,7 @@ event MaxTotalSupplyUpdated(uint256 maxTotalSupply)
 
 
 
-*Emitted when a max total supply is set for a token.*
+*Emitted when the global max supply of tokens is updated.*
 
 #### Parameters
 
@@ -377,7 +377,7 @@ event MaxWalletClaimCountUpdated(uint256 count)
 
 
 
-*Emitted when the max wallet claim count is updated.*
+*Emitted when the global max wallet claim count is updated.*
 
 #### Parameters
 
@@ -393,7 +393,7 @@ event PlatformFeeInfoUpdated(address platformFeeRecipient, uint256 platformFeeBp
 
 
 
-*Emitted when fee on primary sales is updated.*
+*Emitted when fee platform fee recipient or bps is updated.*
 
 #### Parameters
 
@@ -410,7 +410,7 @@ event PrimarySaleRecipientUpdated(address indexed recipient)
 
 
 
-*Emitted when a new sale recipient is set.*
+*Emitted when a new primary sale recipient is set.*
 
 #### Parameters
 
@@ -463,7 +463,7 @@ event WalletClaimCountUpdated(address indexed wallet, uint256 count)
 
 
 
-*Emitted when a wallet claim count is updated.*
+*Emitted when the wallet claim count for an address is updated.*
 
 #### Parameters
 


### PR DESCRIPTION
Pushing `DropERC20` across the finish line — getting it to par with the other Drop contracts that are currently in audit

**Main code changes:**
- Added missing `getClaimConditionById`
- Treating `pricePerToken` in `collectClaimPrice` as 'price per 1 ether unit of the ERC20 token'. So --

Replacing this
```solidity
uint256 totalPrice = _quantityToClaim * _pricePerToken
```

With this
```solidity
uint256 totalPrice = (_quantityToClaim * _pricePerToken) / 1 ether;
```

**Example**: If 'price per token' is 10 USDC, then with the previous code, each wei unit of the ERC20 token would cost 10 USDC; with the changed code, each ether unit of the ERC20 token costs 10 USDC.

Other than code changes -- updated code and natspec comments to get `DropERC20` on par with `DropERC721` and `DropERC1155`.