### PR TITLE
Fix: `quantityLimitPerTransaction` on `Drop` contracts

### DIFF
--- a/docs/DropERC1155.md
+++ b/docs/DropERC1155.md
@@ -131,29 +131,6 @@ function claim(address _receiver, uint256 _tokenId, uint256 _quantity, address _
 | _proofs | bytes32[] | undefined
 | _proofMaxQuantityPerTransaction | uint256 | undefined
 
-### claimCondition
-
-```solidity
-function claimCondition(uint256) external view returns (uint256 currentStartId, uint256 count)
-```
-
-
-
-*Mapping from token ID =&gt; the set of all claim conditions, at any given moment, for tokens of the token ID.*
-
-#### Parameters
-
-| Name | Type | Description |
-|---|---|---|
-| _0 | uint256 | undefined
-
-#### Returns
-
-| Name | Type | Description |
-|---|---|---|
-| currentStartId | uint256 | undefined
-| count | uint256 | undefined
-
 ### contractType
 
 ```solidity

--- a/docs/DropERC721.md
+++ b/docs/DropERC721.md
@@ -66,28 +66,6 @@ function balanceOf(address owner) external view returns (uint256)
 |---|---|---|
 | _0 | uint256 | undefined
 
-### baseURIIndices
-
-```solidity
-function baseURIIndices(uint256) external view returns (uint256)
-```
-
-
-
-*Largest tokenId of each batch of tokens with the same baseURI*
-
-#### Parameters
-
-| Name | Type | Description |
-|---|---|---|
-| _0 | uint256 | undefined
-
-#### Returns
-
-| Name | Type | Description |
-|---|---|---|
-| _0 | uint256 | undefined
-
 ### burn
 
 ```solidity
@@ -124,24 +102,6 @@ function claim(address _receiver, uint256 _quantity, address _currency, uint256 
 | _pricePerToken | uint256 | undefined
 | _proofs | bytes32[] | undefined
 | _proofMaxQuantityPerTransaction | uint256 | undefined
-
-### claimCondition
-
-```solidity
-function claimCondition() external view returns (uint256 currentStartId, uint256 count)
-```
-
-
-
-*The set of all claim conditions, at any given moment.*
-
-
-#### Returns
-
-| Name | Type | Description |
-|---|---|---|
-| currentStartId | uint256 | undefined
-| count | uint256 | undefined
 
 ### contractType
 


### PR DESCRIPTION
This is a fix in response to an exploit on the `Drop` contracts.

## Exploit description

For a `Drop` contract with the following active claim phase:
- No allowlist
- `quantityLimitPerTransaction`: `1`
- `waitTimeInSecondsBetweenClaims`: `type(uint256).max`

The attacker performed the following exploit:
- Create an smart contract (call it `Master`) with a function e.g. `performExploit`
- On calling `performExploit`, `Master` repeats the following cycle:
  - Creates a smart contract  (call it `Sub`).
  - `Sub` performs a claim with `receiver` as any intended receiver (e.g. address of the attacker, or `Master`)
  - `Sub` self destructs

### Consequence
A single account is able to claim _n_ number of tokens in a _single transaction_, where the `quantityLimitPerTransaction` was less than _n_ e.g. 1.

## Fix

We add the following mapping and modifier to `Drop` contracts' `claim` function:
```solidity
/// @dev Mapping from keccak256(tx.origin / caller, block number) => whether caller has already claimed in the block.
mapping(bytes32 => bool) private hasClaimedInBlock;

modifier transactionLimit() {
      /**
       *  A caller (tx.origin) can only call claim once per block. This is to avoid the following exploit:
       *
       *  A master smart contract repeats a cycle of (1) create a new smart contract, (2) created smart contract claim tokens, 
       *  (3) created smart contract transfers back tokens to master contract, then self destructs, (4) repeat.
       */
      bytes32 identifier = keccak256(abi.encodePacked(tx.origin, block.number));
      require(!hasClaimedInBlock[identifier], "LIMIT");
      hasClaimedInBlock[identifier] = true;

      _;
}
```

This modifier restricts all EOAs to at the most 1 `claim` call per block - directly, or indirectly via a chain of smart contract calls. The claim call itself adheres to the `quantityLimitPerTransaction`. As a result, if `quantityLimitPerTransaction == 1`, that means an EOA can at most claim `1` token per block.

### Test for fix

The above fix is tested in `src/test/DropERC721.t.sol` in the test named `test_multiple_claim_exploit`

### (Possibly) Breaking changes to the Drop contracts

To implement the above fix without exceeding the contract size limit, the following changes were made:
- The `uint256[] baseURIIndices` array on all `Drop` contracts now has `private` visibility
- The `ClaimConditionList claimCondition` all `Drop` contracts now has `private` visibility