### PR TITLE
Implement LazyMintERC721 contract extension

### DIFF
--- a/contracts/feature/LazyMintERC721.sol
+++ b/contracts/feature/LazyMintERC721.sol
@@ -3,11 +3,13 @@ pragma solidity ^0.8.0;
 
 import "./LazyMint.sol";
 
-contract LazyMintERC721 is LazyMint {
+abstract contract LazyMintERC721 is LazyMint {
     event TokensLazyMinted(uint256 startTokenId, uint256 endTokenId, string baseURI, bytes extraData);
 
+    /// @dev the next available non-minted token id
     uint256 public nextTokenIdToMint;
 
+    /// @dev lazy mint a batch of tokens
     function lazyMint(
         uint256 amount,
         string calldata baseURIForTokens,
@@ -17,4 +19,7 @@ contract LazyMintERC721 is LazyMint {
         (nextTokenIdToMint, batchId) = _batchMint(startId, amount, baseURIForTokens);
         emit TokensLazyMinted(startId, startId + amount, baseURIForTokens, extraData);
     }
+
+    /// @dev Returns whether lazyMinting can be done in the given execution context.
+    function _canLazyMint() internal virtual returns (bool);
 }

--- a/contracts/feature/LazyMintERC721.sol
+++ b/contracts/feature/LazyMintERC721.sol
@@ -15,13 +15,13 @@ abstract contract LazyMintERC721 is LazyMint {
         string calldata baseURIForTokens,
         bytes calldata extraData
     ) external virtual override returns (uint256 batchId) {
-        require(amount > 0, "amount must be greater than 0");
+        require(amount > 0, "Amount must be greater than 0");
         require(_canLazyMint(), "Not authorized");
         uint256 startId = nextTokenIdToMint;
         (nextTokenIdToMint, batchId) = _batchMint(startId, amount, baseURIForTokens);
         emit TokensLazyMinted(startId, startId + amount, baseURIForTokens, extraData);
     }
 
-    /// @dev Returns whether lazyMinting can be done in the given execution context.
+    /// @dev Returns whether lazy minting can be done in the given execution context.
     function _canLazyMint() internal virtual returns (bool);
 }

--- a/contracts/feature/LazyMintERC721.sol
+++ b/contracts/feature/LazyMintERC721.sol
@@ -15,6 +15,8 @@ abstract contract LazyMintERC721 is LazyMint {
         string calldata baseURIForTokens,
         bytes calldata extraData
     ) external virtual override returns (uint256 batchId) {
+        require(amount > 0, "amount must be greater than 0");
+        require(_canLazyMint(), "Not authorized");
         uint256 startId = nextTokenIdToMint;
         (nextTokenIdToMint, batchId) = _batchMint(startId, amount, baseURIForTokens);
         emit TokensLazyMinted(startId, startId + amount, baseURIForTokens, extraData);

--- a/contracts/feature/LazyMintERC721.sol
+++ b/contracts/feature/LazyMintERC721.sol
@@ -2,8 +2,11 @@
 pragma solidity ^0.8.0;
 
 import "./LazyMint.sol";
+import "../lib/TWStrings.sol";
 
 abstract contract LazyMintERC721 is LazyMint {
+    using TWStrings for uint256;
+
     event TokensLazyMinted(uint256 startTokenId, uint256 endTokenId, string baseURI, bytes extraData);
 
     /// @dev the next available non-minted token id
@@ -20,6 +23,12 @@ abstract contract LazyMintERC721 is LazyMint {
         uint256 startId = nextTokenIdToMint;
         (nextTokenIdToMint, batchId) = _batchMint(startId, amount, baseURIForTokens);
         emit TokensLazyMinted(startId, startId + amount, baseURIForTokens, extraData);
+    }
+
+    /// @dev Returns the URI for a given tokenId
+    function tokenURI(uint256 _tokenId) public view virtual returns (string memory) {
+        string memory batchUri = getBaseURI(_tokenId);
+        return string(abi.encodePacked(batchUri, _tokenId.toString()));
     }
 
     /// @dev Returns whether lazy minting can be done in the given execution context.

--- a/contracts/feature/LazyMintERC721.sol
+++ b/contracts/feature/LazyMintERC721.sol
@@ -1,0 +1,20 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity ^0.8.0;
+
+import "./LazyMint.sol";
+
+contract LazyMintERC721 is LazyMint {
+    event TokensLazyMinted(uint256 startTokenId, uint256 endTokenId, string baseURI, bytes extraData);
+
+    uint256 public nextTokenIdToMint;
+
+    function lazyMint(
+        uint256 amount,
+        string calldata baseURIForTokens,
+        bytes calldata extraData
+    ) external virtual override returns (uint256 batchId) {
+        uint256 startId = nextTokenIdToMint;
+        (nextTokenIdToMint, batchId) = _batchMint(startId, amount, baseURIForTokens);
+        emit TokensLazyMinted(startId, startId + amount, baseURIForTokens, extraData);
+    }
+}

--- a/contracts/feature/Permissions.sol
+++ b/contracts/feature/Permissions.sol
@@ -2,7 +2,7 @@
 pragma solidity ^0.8.0;
 
 import "./interface/IPermissions.sol";
-import "../lib/Strings.sol";
+import "../lib/TWStrings.sol";
 
 contract Permissions is IPermissions {
     mapping(bytes32 => mapping(address => bool)) private _hasRole;
@@ -68,9 +68,9 @@ contract Permissions is IPermissions {
                 string(
                     abi.encodePacked(
                         "Permissions: account ",
-                        Strings.toHexString(uint160(account), 20),
+                        TWStrings.toHexString(uint160(account), 20),
                         " is missing role ",
-                        Strings.toHexString(uint256(role), 32)
+                        TWStrings.toHexString(uint256(role), 32)
                     )
                 )
             );
@@ -83,9 +83,9 @@ contract Permissions is IPermissions {
                 string(
                     abi.encodePacked(
                         "Permissions: account ",
-                        Strings.toHexString(uint160(account), 20),
+                        TWStrings.toHexString(uint160(account), 20),
                         " is missing role ",
-                        Strings.toHexString(uint256(role), 32)
+                        TWStrings.toHexString(uint256(role), 32)
                     )
                 )
             );

--- a/contracts/lib/TWStrings.sol
+++ b/contracts/lib/TWStrings.sol
@@ -6,7 +6,7 @@ pragma solidity ^0.8.0;
 /**
  * @dev String operations.
  */
-library Strings {
+library TWStrings {
     bytes16 private constant _HEX_SYMBOLS = "0123456789abcdef";
 
     /**

--- a/docs/LazyMintERC721.md
+++ b/docs/LazyMintERC721.md
@@ -90,6 +90,28 @@ function nextTokenIdToMint() external view returns (uint256)
 |---|---|---|
 | _0 | uint256 | undefined
 
+### tokenURI
+
+```solidity
+function tokenURI(uint256 _tokenId) external view returns (string)
+```
+
+
+
+*Returns the URI for a given tokenId*
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| _tokenId | uint256 | undefined
+
+#### Returns
+
+| Name | Type | Description |
+|---|---|---|
+| _0 | string | undefined
+
 
 
 ## Events

--- a/docs/LazyMintERC721.md
+++ b/docs/LazyMintERC721.md
@@ -1,0 +1,117 @@
+# LazyMintERC721
+
+
+
+
+
+
+
+
+
+## Methods
+
+### getBaseURICount
+
+```solidity
+function getBaseURICount() external view returns (uint256)
+```
+
+
+
+*Returns the number of batches of tokens having the same baseURI.*
+
+
+#### Returns
+
+| Name | Type | Description |
+|---|---|---|
+| _0 | uint256 | undefined
+
+### getBatchIdAtIndex
+
+```solidity
+function getBatchIdAtIndex(uint256 _index) external view returns (uint256)
+```
+
+
+
+*Returns the id for the batch of tokens the given tokenId belongs to.*
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| _index | uint256 | undefined
+
+#### Returns
+
+| Name | Type | Description |
+|---|---|---|
+| _0 | uint256 | undefined
+
+### lazyMint
+
+```solidity
+function lazyMint(uint256 amount, string baseURIForTokens, bytes extraData) external nonpayable returns (uint256 batchId)
+```
+
+
+
+*lazy mint a batch of tokens*
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| amount | uint256 | undefined
+| baseURIForTokens | string | undefined
+| extraData | bytes | undefined
+
+#### Returns
+
+| Name | Type | Description |
+|---|---|---|
+| batchId | uint256 | undefined
+
+### nextTokenIdToMint
+
+```solidity
+function nextTokenIdToMint() external view returns (uint256)
+```
+
+
+
+*the next available non-minted token id*
+
+
+#### Returns
+
+| Name | Type | Description |
+|---|---|---|
+| _0 | uint256 | undefined
+
+
+
+## Events
+
+### TokensLazyMinted
+
+```solidity
+event TokensLazyMinted(uint256 startTokenId, uint256 endTokenId, string baseURI, bytes extraData)
+```
+
+
+
+
+
+#### Parameters
+
+| Name | Type | Description |
+|---|---|---|
+| startTokenId  | uint256 | undefined |
+| endTokenId  | uint256 | undefined |
+| baseURI  | string | undefined |
+| extraData  | bytes | undefined |
+
+
+

--- a/docs/TWStrings.md
+++ b/docs/TWStrings.md
@@ -1,0 +1,12 @@
+# TWStrings
+
+
+
+
+
+
+
+*String operations.*
+
+
+


### PR DESCRIPTION
`LazyMint` is fine if you know what you're doing, but we should have a solution if you just want a plug and play a working lazy mint extension.

This is my attempt at that, with another layer on top of `LazyMint` - scoped to ERC721 (even though it could be generic, i think it aligns well with our other interfaces)