### PR TITLE
Detect roles: add getter for all roles ever used on contract

### DIFF
--- a/contracts/feature/PermissionsEnumerable.sol
+++ b/contracts/feature/PermissionsEnumerable.sol
@@ -13,6 +13,16 @@ contract PermissionsEnumerable is IPermissionsEnumerable, Permissions {
 
     mapping(bytes32 => RoleMembers) private roleMembers;
 
+    bytes32[] private roles;
+
+    function getAllRoles() external view returns (bytes32[] memory allRoles) {
+        allRoles = new bytes32[](roles.length);
+
+        for(uint256 i = 0; i < roles.length; i += 1) {
+            allRoles[i] = roles[i];
+        }
+    }
+
     function getRoleMember(bytes32 role, uint256 index) external view override returns (address member) {
         uint256 currentIndex = roleMembers[role].index;
         uint256 check;
@@ -28,7 +38,7 @@ contract PermissionsEnumerable is IPermissionsEnumerable, Permissions {
         }
     }
 
-    function getRoleMemberCount(bytes32 role) external view override returns (uint256 count) {
+    function getRoleMemberCount(bytes32 role) public view override returns (uint256 count) {
         uint256 currentIndex = roleMembers[role].index;
 
         for (uint256 i = 0; i < currentIndex; i += 1) {
@@ -60,7 +70,11 @@ contract PermissionsEnumerable is IPermissionsEnumerable, Permissions {
 
     function _addMember(bytes32 role, address account) internal {
         uint256 idx = roleMembers[role].index;
-        roleMembers[role].index += 1;
+        if(idx == 0) {
+            roles.push(role);
+        }
+
+       roleMembers[role].index += 1;
 
         roleMembers[role].members[idx] = account;
         roleMembers[role].indexOf[account] = idx;

--- a/docs/Multiwrap.md
+++ b/docs/Multiwrap.md
@@ -117,6 +117,40 @@ function contractVersion() external pure returns (uint8)
 |---|---|---|
 | _0 | uint8 | undefined
 
+### getAllRoles
+
+```solidity
+function getAllRoles() external view returns (bytes32[] allRoles)
+```
+
+
+
+
+
+
+#### Returns
+
+| Name | Type | Description |
+|---|---|---|
+| allRoles | bytes32[] | undefined
+
+### getAllRolesWithMembers
+
+```solidity
+function getAllRolesWithMembers() external view returns (bytes32[] rolesWithMembers)
+```
+
+
+
+
+
+
+#### Returns
+
+| Name | Type | Description |
+|---|---|---|
+| rolesWithMembers | bytes32[] | undefined
+
 ### getApproved
 
 ```solidity

--- a/docs/PermissionsEnumerable.md
+++ b/docs/PermissionsEnumerable.md
@@ -27,6 +27,40 @@ function DEFAULT_ADMIN_ROLE() external view returns (bytes32)
 |---|---|---|
 | _0 | bytes32 | undefined
 
+### getAllRoles
+
+```solidity
+function getAllRoles() external view returns (bytes32[] allRoles)
+```
+
+
+
+
+
+
+#### Returns
+
+| Name | Type | Description |
+|---|---|---|
+| allRoles | bytes32[] | undefined
+
+### getAllRolesWithMembers
+
+```solidity
+function getAllRolesWithMembers() external view returns (bytes32[] rolesWithMembers)
+```
+
+
+
+
+
+
+#### Returns
+
+| Name | Type | Description |
+|---|---|---|
+| rolesWithMembers | bytes32[] | undefined
+
 ### getRoleAdmin
 
 ```solidity

--- a/docs/SignatureDrop.md
+++ b/docs/SignatureDrop.md
@@ -223,6 +223,40 @@ function encryptedBaseURI(uint256) external view returns (bytes)
 |---|---|---|
 | _0 | bytes | undefined
 
+### getAllRoles
+
+```solidity
+function getAllRoles() external view returns (bytes32[] allRoles)
+```
+
+
+
+
+
+
+#### Returns
+
+| Name | Type | Description |
+|---|---|---|
+| allRoles | bytes32[] | undefined
+
+### getAllRolesWithMembers
+
+```solidity
+function getAllRolesWithMembers() external view returns (bytes32[] rolesWithMembers)
+```
+
+
+
+
+
+
+#### Returns
+
+| Name | Type | Description |
+|---|---|---|
+| rolesWithMembers | bytes32[] | undefined
+
 ### getApproved
 
 ```solidity

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -135,7 +135,7 @@ const config: HardhatUserConfig = {
     enabled: process.env.REPORT_GAS ? true : false,
   },
   dodoc: {
-    runOnCompile: true,
+    runOnCompile: false,
   },
 };
 


### PR DESCRIPTION
## Problem

For contracts that use `AccessControlEnumerable` or `PermissionsEnumerable`, listening to contract events is required for programmatically detecting what particular roles are being used on the contract.

## Solution
This PR introduces a function `getAllRoles` to `feature/PermissionsEnumerable.sol` which returns a list of roles that, at least at one point in the existence of the contract, were held by a wallet.

### Notes
- The size increment of adding `getAllRoles` to the `PermissionsEnumerable` contract is `0.358 kb`.
- Since the `PermissionsEnumerable` contract is inherited by multiple thirdweb pre-built contracts (e.g. `Multiwrap`, and `SignatureDrop`), the relevant pre-built contracts also experience this increase in size.
- `SignatureDrop` is pushed over the contract size limit, as a result of the above mentioned size increase. **We must ensure that the size issue for `SignatureDrop` is resolved before merging this PR.**