### PR TITLE
Drop bug fix: replace MerkleProofindex with type casted address of claimer

### DIFF
--- a/contracts/drop/DropERC1155.sol
+++ b/contracts/drop/DropERC1155.sol
@@ -275,7 +275,7 @@ contract DropERC1155 is
          */
 
         // Verify inclusion in allowlist.
-        (bool validMerkleProof, uint256 merkleProofIndex) = verifyClaimMerkleProof(
+        (bool validMerkleProof, ) = verifyClaimMerkleProof(
             activeConditionId,
             _msgSender(),
             _tokenId,
@@ -304,7 +304,7 @@ contract DropERC1155 is
              *  Mark the claimer's use of their position in the allowlist. A spot in an allowlist
              *  can be used only once.
              */
-            claimCondition[_tokenId].limitMerkleProofClaim[activeConditionId].set(merkleProofIndex);
+            claimCondition[_tokenId].limitMerkleProofClaim[activeConditionId].set(uint256(uint160(_msgSender())));
         }
 
         // If there's a price, collect price.
@@ -490,7 +490,7 @@ contract DropERC1155 is
             );
             require(validMerkleProof, "not in whitelist.");
             require(
-                !claimCondition[_tokenId].limitMerkleProofClaim[_conditionId].get(merkleProofIndex),
+                !claimCondition[_tokenId].limitMerkleProofClaim[_conditionId].get(uint256(uint160(_claimer))),
                 "proof claimed."
             );
             require(

--- a/contracts/drop/DropERC20.sol
+++ b/contracts/drop/DropERC20.sol
@@ -194,7 +194,7 @@ contract DropERC20 is
          */
 
         // Verify inclusion in allowlist.
-        (bool validMerkleProof, uint256 merkleProofIndex) = verifyClaimMerkleProof(
+        (bool validMerkleProof, ) = verifyClaimMerkleProof(
             activeConditionId,
             _msgSender(),
             _quantity,
@@ -221,7 +221,7 @@ contract DropERC20 is
              *  Mark the claimer's use of their position in the allowlist. A spot in an allowlist
              *  can be used only once.
              */
-            claimCondition.limitMerkleProofClaim[activeConditionId].set(merkleProofIndex);
+            claimCondition.limitMerkleProofClaim[activeConditionId].set(uint256(uint160(_msgSender())));
         }
 
         // If there's a price, collect price.
@@ -396,7 +396,10 @@ contract DropERC20 is
                 keccak256(abi.encodePacked(_claimer, _proofMaxQuantityPerTransaction))
             );
             require(validMerkleProof, "not in whitelist.");
-            require(!claimCondition.limitMerkleProofClaim[_conditionId].get(merkleProofIndex), "proof claimed.");
+            require(
+                !claimCondition.limitMerkleProofClaim[_conditionId].get(uint256(uint160(_claimer))),
+                "proof claimed."
+            );
             require(
                 _proofMaxQuantityPerTransaction == 0 || _quantity <= _proofMaxQuantityPerTransaction,
                 "invalid quantity proof."

--- a/contracts/drop/DropERC721.sol
+++ b/contracts/drop/DropERC721.sol
@@ -347,7 +347,7 @@ contract DropERC721 is
          */
 
         // Verify inclusion in allowlist.
-        (bool validMerkleProof, uint256 merkleProofIndex) = verifyClaimMerkleProof(
+        (bool validMerkleProof, ) = verifyClaimMerkleProof(
             activeConditionId,
             _msgSender(),
             _quantity,
@@ -374,7 +374,7 @@ contract DropERC721 is
              *  Mark the claimer's use of their position in the allowlist. A spot in an allowlist
              *  can be used only once.
              */
-            claimCondition.limitMerkleProofClaim[activeConditionId].set(merkleProofIndex);
+            claimCondition.limitMerkleProofClaim[activeConditionId].set(uint256(uint160(_msgSender())));
         }
 
         // If there's a price, collect price.
@@ -549,7 +549,10 @@ contract DropERC721 is
                 keccak256(abi.encodePacked(_claimer, _proofMaxQuantityPerTransaction))
             );
             require(validMerkleProof, "not in whitelist.");
-            require(!claimCondition.limitMerkleProofClaim[_conditionId].get(merkleProofIndex), "proof claimed.");
+            require(
+                !claimCondition.limitMerkleProofClaim[_conditionId].get(uint256(uint160(_claimer))),
+                "proof claimed."
+            );
             require(
                 _proofMaxQuantityPerTransaction == 0 || _quantity <= _proofMaxQuantityPerTransaction,
                 "invalid quantity proof."

--- a/contracts/extension/DropSinglePhase.sol
+++ b/contracts/extension/DropSinglePhase.sol
@@ -59,11 +59,7 @@ abstract contract DropSinglePhase is IDropSinglePhase {
          */
 
         // Verify inclusion in allowlist.
-        (bool validMerkleProof, uint256 merkleProofIndex) = verifyClaimMerkleProof(
-            _dropMsgSender(),
-            _quantity,
-            _allowlistProof
-        );
+        (bool validMerkleProof, ) = verifyClaimMerkleProof(_dropMsgSender(), _quantity, _allowlistProof);
 
         // Verify claim validity. If not valid, revert.
         // when there's allowlist present --> verifyClaimMerkleProof will verify the maxQuantityInAllowlist value with hashed leaf in the allowlist
@@ -78,7 +74,7 @@ abstract contract DropSinglePhase is IDropSinglePhase {
              *  Mark the claimer's use of their position in the allowlist. A spot in an allowlist
              *  can be used only once.
              */
-            usedAllowlistSpot[activeConditionId].set(merkleProofIndex);
+            usedAllowlistSpot[activeConditionId].set(uint256(uint160(_dropMsgSender())));
         }
 
         // Update contract state.
@@ -182,7 +178,7 @@ abstract contract DropSinglePhase is IDropSinglePhase {
                 revert("not in allowlist");
             }
 
-            if (usedAllowlistSpot[conditionId].get(merkleProofIndex)) {
+            if (usedAllowlistSpot[conditionId].get(uint256(uint160(_claimer)))) {
                 revert("proof claimed");
             }
 

--- a/contracts/extension/DropSinglePhase1155.sol
+++ b/contracts/extension/DropSinglePhase1155.sol
@@ -57,12 +57,7 @@ abstract contract DropSinglePhase1155 is IDropSinglePhase1155 {
          */
 
         // Verify inclusion in allowlist.
-        (bool validMerkleProof, uint256 merkleProofIndex) = verifyClaimMerkleProof(
-            _tokenId,
-            _dropMsgSender(),
-            _quantity,
-            _allowlistProof
-        );
+        (bool validMerkleProof, ) = verifyClaimMerkleProof(_tokenId, _dropMsgSender(), _quantity, _allowlistProof);
 
         // Verify claim validity. If not valid, revert.
         // when there's allowlist present --> verifyClaimMerkleProof will verify the maxQuantityInAllowlist value with hashed leaf in the allowlist
@@ -84,7 +79,7 @@ abstract contract DropSinglePhase1155 is IDropSinglePhase1155 {
              *  Mark the claimer's use of their position in the allowlist. A spot in an allowlist
              *  can be used only once.
              */
-            usedAllowlistSpot[activeConditionId].set(merkleProofIndex);
+            usedAllowlistSpot[activeConditionId].set(uint256(uint160(_dropMsgSender())));
         }
 
         // Update contract state.
@@ -199,7 +194,7 @@ abstract contract DropSinglePhase1155 is IDropSinglePhase1155 {
                 revert("not in allowlist");
             }
 
-            if (usedAllowlistSpot[conditionId[_tokenId]].get(merkleProofIndex)) {
+            if (usedAllowlistSpot[conditionId[_tokenId]].get(uint256(uint160(_claimer)))) {
                 revert("proof claimed");
             }
 


### PR DESCRIPTION
### Before
```Solidity
// Setting the BitMap value when an allowlisted claimer claims tokens
claimCondition.limitMerkleProofClaim[activeConditionId].set(merkleProofIndex);

// Checking if 'BitMap value' has been set for a claimer. This 'BitMap value' is the `merkleProofIndex` of the claimer.
require(!claimCondition.limitMerkleProofClaim[_conditionId].get(merkleProofIndex), "proof claimed.");
```

### After
```Solidity

address claimerAddress;

// Setting the BitMap value when an allowlisted claimer claims tokens
claimCondition.limitMerkleProofClaim[activeConditionId].set(uint256(uint160(claimerAddress)));

// Checking if 'BitMap value' has been set for a claimer. This 'BitMap value' is the type casted of the claimer.
require(!claimCondition.limitMerkleProofClaim[_conditionId].get(uint256(uint160(claimerAddress))), "proof claimed.");
```

### Reason for the change.
In the `After` case, the BitMap value for a `claimer x claim_condition` is unique for the claimer. This is different from using `merkleProofIndex`, since that can be the same for 2 different addresses (each included in a separate allowlist of separate claim conditions, but at the same position i.e. with the same condition Id).