### PR TITLE
Remove `virtual` from `claim` of LazyMint bases

### DIFF
--- a/contracts/base/ERC721LazyMint.sol
+++ b/contracts/base/ERC721LazyMint.sol
@@ -101,15 +101,20 @@ contract ERC721LazyMint is
 
     /**
      *  @notice          Lets an address claim multiple lazy minted NFTs at once to a recipient.
-     *                   Contract creators should override this function to create custom logic for claiming,
+     *                   This function prevents any reentrant calls, and is not allowed to be overridden.
+     *
+     *                   Contract creators should override `verifyClaim` and `transferTokensOnClaim`
+     *                   functions to create custom logic for verification and claiming,
      *                   for e.g. price collection, allowlist, max quantity, etc.
      *
-     *  @dev             The logic in the `verifyClaim` function determines whether the caller is authorized to mint NFTs.
+     *  @dev             The logic in `verifyClaim` determines whether the caller is authorized to mint NFTs.
+     *                   The logic in `transferTokensOnClaim` does actual minting of tokens,
+     *                   can also be used to apply other state changes.
      *
      *  @param _receiver  The recipient of the NFT to mint.
      *  @param _quantity  The number of NFTs to mint.
      */
-    function claim(address _receiver, uint256 _quantity) public payable virtual nonReentrant {
+    function claim(address _receiver, uint256 _quantity) public payable nonReentrant {
         require(_currentIndex + _quantity <= nextTokenIdToLazyMint, "Not enough lazy minted tokens.");
         verifyClaim(msg.sender, _quantity); // Add your claim verification logic by overriding this function.
 
@@ -154,9 +159,11 @@ contract ERC721LazyMint is
 
     /**
      *  @notice          Mints tokens to receiver on claim.
-     *                   Can also use this function to apply any state changes before minting.
+     *                   Any state changes related to `claim` must be applied
+     *                   here by overriding this function.
      *
      *  @dev             Override this function to add logic for state updation.
+     *                   When overriding, apply any state changes before `_safeMint`.
      */
     function transferTokensOnClaim(address _receiver, uint256 _quantity)
         internal


### PR DESCRIPTION
Should use `verifyClaim` and `transferTokensOnClaim` for custom logic.