### PR TITLE
fix: add virtual so that function can be overriden

### DIFF
--- a/contracts/base/Staking1155Base.sol
+++ b/contracts/base/Staking1155Base.sol
@@ -60,7 +60,7 @@ contract Staking1155Base is ContractMetadata, Multicall, Ownable, Staking1155 {
      *  @param _rewards   Amount of tokens to be given out as reward.
      *
      */
-    function _mintRewards(address _staker, uint256 _rewards) internal override {
+    function _mintRewards(address _staker, uint256 _rewards) internal virtual override {
         // Mint or transfer reward-tokens here.
         // e.g.
         //

--- a/contracts/base/Staking20Base.sol
+++ b/contracts/base/Staking20Base.sol
@@ -62,7 +62,7 @@ contract Staking20Base is ContractMetadata, Multicall, Ownable, Staking20 {
      *  @param _rewards   Amount of tokens to be given out as reward.
      *
      */
-    function _mintRewards(address _staker, uint256 _rewards) internal override {
+    function _mintRewards(address _staker, uint256 _rewards) internal virtual override {
         // Mint or transfer reward-tokens here.
         // e.g.
         //

--- a/contracts/base/Staking721Base.sol
+++ b/contracts/base/Staking721Base.sol
@@ -60,7 +60,7 @@ contract Staking721Base is ContractMetadata, Multicall, Ownable, Staking721 {
      *  @param _rewards   Amount of tokens to be given out as reward.
      *
      */
-    function _mintRewards(address _staker, uint256 _rewards) internal override {
+    function _mintRewards(address _staker, uint256 _rewards) internal virtual override {
         // Mint or transfer reward-tokens here.
         // e.g.
         //


### PR DESCRIPTION
currently receiving error that function must be virtual to override, did some digging and discovered that `_mintRewards()` should have been virtual instead