### PR TITLE
Update OperatorFilterToggle.sol

### DIFF
--- a/contracts/extension/OperatorFilterToggle.sol
+++ b/contracts/extension/OperatorFilterToggle.sol
@@ -16,5 +16,5 @@ abstract contract OperatorFilterToggle is IOperatorFilterToggle {
         emit OperatorRestriction(_restriction);
     }
 
-    function _canSetOperatorRestriction() internal virtual returns (bool);
+    function _canSetOperatorRestriction() internal virtual returns (bool){};
 }


### PR DESCRIPTION
Changing 

function _canSetOperatorRestriction() internal virtual returns (bool);

TO

function _canSetOperatorRestriction() internal virtual returns (bool){}

It was missing the curly brackets in order for the function to be implemented, otherwise you will need to abstract the contract or it will not compile.