### PR TITLE
Change uint128 to uint256 in Staking721Base to maintain consistency

### DIFF
--- a/contracts/base/Staking721Base.sol
+++ b/contracts/base/Staking721Base.sol
@@ -36,8 +36,8 @@ contract Staking721Base is ContractMetadata, Multicall, Ownable, Staking721 {
     address public rewardToken;
 
     constructor(
-        uint128 _timeUnit,
-        uint128 _rewardsPerUnitTime,
+        uint256 _timeUnit,
+        uint256 _rewardsPerUnitTime,
         address _stakingToken,
         address _rewardToken
     ) Staking721(_stakingToken) {


### PR DESCRIPTION
In Staking20Base and Staking1155Base, the constructor params are `uint256` but in Staking721Base it is `uint128`. In the docs it's mentioned `uint256`. I believe to maintain consistency this should be `uint256`