### PR TITLE
update foundry.toml

### DIFF
--- a/foundry.toml
+++ b/foundry.toml
@@ -1,4 +1,4 @@
-[default]
+[profile.default]
 solc-version = "0.8.12"
 #auto_detect_solc = false
 cache = true


### PR DESCRIPTION
The notation for profiles has been deprecated and may result in the profile not being registered in future versions.