### PR TITLE
extension: Fix documentation tag in LazyMint.sol

### DIFF
--- a/contracts/extension/LazyMint.sol
+++ b/contracts/extension/LazyMint.sol
@@ -11,7 +11,7 @@ import "./BatchMintMetadata.sol";
  */
 
 abstract contract LazyMint is ILazyMint, BatchMintMetadata {
-    /// @notice The tokenId assigned to the next new NFT to be lazy minted.
+    /// @dev The tokenId assigned to the next new NFT to be lazy minted.
     uint256 internal nextTokenIdToLazyMint;
 
     /**


### PR DESCRIPTION
I had an error when compiling source with solc v0.8.0.
Documentation tag @notice not valid for non-public state variables.