### PR TITLE
[Account] Return false instead of reverting to allow for dummy simulations

### DIFF
--- a/contracts/smart-wallet/non-upgradeable/Account.sol
+++ b/contracts/smart-wallet/non-upgradeable/Account.sol
@@ -111,12 +111,14 @@ contract Account is
             SignerPermissionsStatic memory permissions = data.signerPermissions[_signer];
 
             // If not an admin, check if the signer is active.
-            require(
-                permissions.startTimestamp <= block.timestamp &&
-                    block.timestamp < permissions.endTimestamp &&
-                    data.approvedTargets[_signer].length() > 0,
-                "Account: no active permissions."
-            );
+            if (
+                permissions.startTimestamp > block.timestamp ||
+                block.timestamp >= permissions.endTimestamp ||
+                data.approvedTargets[_signer].length() == 0
+            ) {
+                // Account: no active permissions.
+                return false;
+            }
 
             // Extract the function signature from the userOp calldata and check whether the signer is attempting to call `execute` or `executeBatch`.
             bytes4 sig = getFunctionSignature(_userOp.callData);
@@ -126,19 +128,32 @@ contract Account is
                 (address target, uint256 value) = decodeExecuteCalldata(_userOp.callData);
 
                 // Check if the value is within the allowed range and if the target is approved.
-                require(permissions.nativeTokenLimitPerTransaction >= value, "Account: value too high.");
-                require(data.approvedTargets[_signer].contains(target), "Account: target not approved.");
+                if (permissions.nativeTokenLimitPerTransaction < value) {
+                    // Account: value too high.
+                    return false;
+                }
+                if (!data.approvedTargets[_signer].contains(target)) {
+                    // Account: target not approved.
+                    return false;
+                }
             } else if (sig == this.executeBatch.selector) {
                 // Extract the `target` and `value` array arguments from the calldata for `executeBatch`.
                 (address[] memory targets, uint256[] memory values, ) = decodeExecuteBatchCalldata(_userOp.callData);
 
                 // For each target+value pair, check if the value is within the allowed range and if the target is approved.
                 for (uint256 i = 0; i < targets.length; i++) {
-                    require(permissions.nativeTokenLimitPerTransaction >= values[i], "Account: value too high.");
-                    require(data.approvedTargets[_signer].contains(targets[i]), "Account: target not approved.");
+                    if (permissions.nativeTokenLimitPerTransaction < values[i]) {
+                        // Account: value too high.
+                        return false;
+                    }
+                    if (!data.approvedTargets[_signer].contains(targets[i])) {
+                        // Account: target not approved.
+                        return false;
+                    }
                 }
             } else {
-                revert("Account: calling invalid fn.");
+                // Account: calling invalid fn.
+                return false;
             }
 
             return true;


### PR DESCRIPTION
eth_estimateUserOperationGas and pm_sponsorUserOperation (stackup style) typically allow for dummy sigs to be passed for simulation/gas estimation purposes. Currently we either return true or revert here, never returning the `1` the entrypoint understands.

We could still revert in non-signer related cases here if you think it is needed.