### PR TITLE
Fix forge release script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@ contracts/abi/
 contracts/README.md
 artifacts/
 artifacts_forge/
+contract_artifacts/
 
 # files
 *.env

--- a/contracts/airdrop/AirdropERC721.sol
+++ b/contracts/airdrop/AirdropERC721.sol
@@ -13,7 +13,7 @@ pragma solidity ^0.8.11;
 //    \____/ \__|  \__|\__|\__|       \_______| \_____\____/  \_______|\_______/
 
 //  ==========  External imports    ==========
-import "@openzeppelin/contracts/token/ERC721/IERC721.sol";
+import "../eip/interface/IERC721.sol";
 
 import "@openzeppelin/contracts-upgradeable/security/ReentrancyGuardUpgradeable.sol";
 import "@openzeppelin/contracts-upgradeable/utils/MulticallUpgradeable.sol";

--- a/contracts/airdrop/AirdropERC721Claimable.sol
+++ b/contracts/airdrop/AirdropERC721Claimable.sol
@@ -13,7 +13,7 @@ pragma solidity ^0.8.11;
 //    \____/ \__|  \__|\__|\__|       \_______| \_____\____/  \_______|\_______/
 
 //  ==========  External imports    ==========
-import "@openzeppelin/contracts/token/ERC721/IERC721.sol";
+import "../eip/interface/IERC721.sol";
 
 import "@openzeppelin/contracts-upgradeable/security/ReentrancyGuardUpgradeable.sol";
 import "@openzeppelin/contracts-upgradeable/utils/MulticallUpgradeable.sol";

--- a/contracts/extension/Staking721Upgradeable.sol
+++ b/contracts/extension/Staking721Upgradeable.sol
@@ -5,7 +5,7 @@ pragma solidity ^0.8.11;
 
 import "@openzeppelin/contracts-upgradeable/security/ReentrancyGuardUpgradeable.sol";
 import "../openzeppelin-presets/utils/math/SafeMath.sol";
-import "@openzeppelin/contracts/token/ERC721/IERC721.sol";
+import "../eip/interface/IERC721.sol";
 
 import "./interface/IStaking721.sol";
 

--- a/contracts/marketplace/direct-listings/DirectListingsLogic.sol
+++ b/contracts/marketplace/direct-listings/DirectListingsLogic.sol
@@ -7,7 +7,7 @@ import "./DirectListingsStorage.sol";
 
 // ====== External imports ======
 import "@openzeppelin/contracts/token/ERC1155/IERC1155.sol";
-import "@openzeppelin/contracts/token/ERC721/IERC721.sol";
+import "../../eip/interface/IERC721.sol";
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import "@openzeppelin/contracts/interfaces/IERC2981.sol";
 

--- a/contracts/marketplace/english-auctions/EnglishAuctionsLogic.sol
+++ b/contracts/marketplace/english-auctions/EnglishAuctionsLogic.sol
@@ -9,7 +9,7 @@ import "./EnglishAuctionsStorage.sol";
 import "@openzeppelin/contracts/utils/Context.sol";
 import "@openzeppelin/contracts/utils/introspection/IERC165.sol";
 import "@openzeppelin/contracts/token/ERC1155/IERC1155.sol";
-import "@openzeppelin/contracts/token/ERC721/IERC721.sol";
+import "../../eip/interface/IERC721.sol";
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import "@openzeppelin/contracts/interfaces/IERC2981.sol";
 

--- a/contracts/marketplace/offers/OffersLogic.sol
+++ b/contracts/marketplace/offers/OffersLogic.sol
@@ -8,7 +8,7 @@ import "./OffersStorage.sol";
 // ====== External imports ======
 import "@openzeppelin/contracts/utils/Context.sol";
 import "@openzeppelin/contracts/utils/introspection/IERC165.sol";
-import "@openzeppelin/contracts/token/ERC721/IERC721.sol";
+import "../../eip/interface/IERC721.sol";
 import "@openzeppelin/contracts/token/ERC1155/IERC1155.sol";
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import "@openzeppelin/contracts/interfaces/IERC2981.sol";

--- a/contracts/mock/Mock.sol
+++ b/contracts/mock/Mock.sol
@@ -4,7 +4,7 @@ pragma solidity ^0.8.11;
 /// @author thirdweb
 
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
-import "@openzeppelin/contracts/token/ERC721/IERC721.sol";
+import "../eip/interface/IERC721.sol";
 import "@openzeppelin/contracts/token/ERC1155/IERC1155.sol";
 
 /*

--- a/contracts/package.json
+++ b/contracts/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@thirdweb-dev/contracts",
   "description": "Collection of smart contracts deployable via the thirdweb SDK, dashboard and CLI",
-  "version": "3.8.4-6",
+  "version": "3.8.4-7",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/contracts/package.json
+++ b/contracts/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@thirdweb-dev/contracts",
   "description": "Collection of smart contracts deployable via the thirdweb SDK, dashboard and CLI",
-  "version": "3.8.4-7",
+  "version": "3.8.4-8",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/contracts/package.json
+++ b/contracts/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@thirdweb-dev/contracts",
   "description": "Collection of smart contracts deployable via the thirdweb SDK, dashboard and CLI",
-  "version": "3.8.4-1",
+  "version": "3.8.4-5",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/contracts/package.json
+++ b/contracts/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@thirdweb-dev/contracts",
   "description": "Collection of smart contracts deployable via the thirdweb SDK, dashboard and CLI",
-  "version": "3.8.4-5",
+  "version": "3.8.4-6",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/contracts/package.json
+++ b/contracts/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@thirdweb-dev/contracts",
   "description": "Collection of smart contracts deployable via the thirdweb SDK, dashboard and CLI",
-  "version": "3.8.4-9",
+  "version": "3.8.4",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/contracts/package.json
+++ b/contracts/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@thirdweb-dev/contracts",
   "description": "Collection of smart contracts deployable via the thirdweb SDK, dashboard and CLI",
-  "version": "3.8.4-8",
+  "version": "3.8.4-9",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/contracts/staking/NFTStake.sol
+++ b/contracts/staking/NFTStake.sol
@@ -13,7 +13,7 @@ pragma solidity ^0.8.11;
 //    \____/ \__|  \__|\__|\__|       \_______| \_____\____/  \_______|\_______/
 
 // Token
-import "@openzeppelin/contracts/token/ERC721/IERC721.sol";
+import "../eip/interface/IERC721.sol";
 import "@openzeppelin/contracts-upgradeable/utils/introspection/ERC165Upgradeable.sol";
 import "@openzeppelin/contracts-upgradeable/token/ERC721/IERC721ReceiverUpgradeable.sol";
 

--- a/package.json
+++ b/package.json
@@ -46,8 +46,8 @@
     "typescript": "^4.4.4"
   },
   "scripts": {
-    "clean": "forge clean && rm -rf abi/ && rm -rf artifacts_forge/ && rm -rf dist/ && rm -rf typechain/",
-    "compile": "forge build",
+    "clean": "forge clean && rm -rf abi/ && rm -rf artifacts_forge/ && rm -rf contract_artifacts && rm -rf dist/ && rm -rf typechain/",
+    "compile": "forge build && npx ts-node scripts/package-release.ts",
     "lint": "solhint \"contracts/**/*.sol\"",
     "prettier": "prettier --config .prettierrc --write \"{contracts,src}/**/*.{js,json,sol,ts}\"",
     "prettier:list-different": "prettier --config .prettierrc --list-different \"**/*.{js,json,sol,ts}\"",

--- a/release.sh
+++ b/release.sh
@@ -35,12 +35,7 @@ echo "### Build finished. Copying abis."
 rm -rf contracts/abi
 mkdir -p contracts/abi
 # copy all abis to contracts/abi
-find artifacts_forge -type f -iname "*.json" \
-    ! -path "artifacts_forge/*.t.sol*" \
-    ! -path "artifacts_forge/*test*" \
-    ! -path "artifacts_forge/*mock*" \
-    -exec cp {} contracts/abi 2>/dev/null \;
- 
+find contract_artifacts ! -iregex ".*([a-zA-Z0-9_]).json" -exec cp {} contracts/abi 2>/dev/null \; 
 echo "### Copying README."
 # copy root README to contracts folder
 cp README.md contracts/README.md

--- a/release.sh
+++ b/release.sh
@@ -35,7 +35,12 @@ echo "### Build finished. Copying abis."
 rm -rf contracts/abi
 mkdir -p contracts/abi
 # copy all abis to contracts/abi
-find artifacts_forge ! -iregex ".*([a-zA-Z0-9_]).json" -exec cp {} contracts/abi 2>/dev/null \; 
+find artifacts_forge -type f -iname "*.json" \
+    ! -path "artifacts_forge/*.t.sol*" \
+    ! -path "artifacts_forge/*test*" \
+    ! -path "artifacts_forge/*mock*" \
+    -exec cp {} contracts/abi 2>/dev/null \;
+ 
 echo "### Copying README."
 # copy root README to contracts folder
 cp README.md contracts/README.md

--- a/scripts/package-release.ts
+++ b/scripts/package-release.ts
@@ -1,0 +1,52 @@
+import * as fs from "fs-extra";
+import * as path from "path";
+
+// Define the paths for the directories
+const artifactsForgeDir = path.join(__dirname, "..", "artifacts_forge");
+const contractsDir = path.join(__dirname, "..", "contracts");
+const contractArtifactsDir = path.join(__dirname, "..", "contract_artifacts");
+
+async function getAllSolidityFiles(dir: string): Promise<string[]> {
+  const dirents = await fs.readdir(dir, { withFileTypes: true });
+  const files = await Promise.all(
+    dirents.map(dirent => {
+      const res = path.join(dir, dirent.name);
+      return dirent.isDirectory() ? getAllSolidityFiles(res) : res;
+    }),
+  );
+  // Flatten the array and filter for .sol files
+  return files
+    .flat()
+    .filter(file => file.endsWith(".sol"))
+    .map(file => path.basename(file));
+}
+
+async function main() {
+  // Create the contract_artifacts directory
+  await fs.ensureDir(contractArtifactsDir);
+
+  // Get all directories within artifacts_forge that match *.sol
+  const artifactDirs = await fs.readdir(artifactsForgeDir);
+  const validArtifactDirs = artifactDirs.filter(dir => dir.endsWith(".sol"));
+
+  // Get all .sol filenames within contracts (recursively)
+  const validContractFiles = await getAllSolidityFiles(contractsDir);
+
+  // Check if directory-name matches any Solidity file name from contracts
+  for (const artifactDir of validArtifactDirs) {
+    // Removing the .sol extension from the directory name to match with file names
+    const artifactName = path.basename(artifactDir, ".sol");
+
+    if (validContractFiles.includes(artifactName + ".sol")) {
+      const sourcePath = path.join(artifactsForgeDir, artifactDir);
+      const destinationPath = path.join(contractArtifactsDir, artifactDir);
+      await fs.copy(sourcePath, destinationPath);
+    }
+  }
+
+  console.log("Done copying matching directories.");
+}
+
+main().catch(error => {
+  console.error("An error occurred:", error);
+});

--- a/src/test/airdrop/AirdropERC721.t.sol
+++ b/src/test/airdrop/AirdropERC721.t.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 pragma solidity ^0.8.0;
 
-import "contracts/airdrop/AirdropERC721.sol";
+import { AirdropERC721, IAirdropERC721 } from "contracts/airdrop/AirdropERC721.sol";
 
 // Test imports
 import { Wallet } from "../utils/Wallet.sol";

--- a/src/test/benchmark/AirdropERC721Benchmark.t.sol
+++ b/src/test/benchmark/AirdropERC721Benchmark.t.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 pragma solidity ^0.8.0;
 
-import "contracts/airdrop/AirdropERC721.sol";
+import { AirdropERC721, IAirdropERC721 } from "contracts/airdrop/AirdropERC721.sol";
 
 // Test imports
 import { Wallet } from "../utils/Wallet.sol";

--- a/src/test/sdk/base/BaseUtilTest.sol
+++ b/src/test/sdk/base/BaseUtilTest.sol
@@ -11,7 +11,7 @@ import "../../mocks/MockERC1155.sol";
 import "contracts/forwarder/Forwarder.sol";
 import "contracts/lib/TWStrings.sol";
 
-import "contracts/mock/Mock.sol";
+import { Mock } from "contracts/mock/Mock.sol";
 
 abstract contract BaseUtilTest is DSTest, Test {
     string public constant NAME = "NAME";

--- a/src/test/sdk/extension/StakingExtension.t.sol
+++ b/src/test/sdk/extension/StakingExtension.t.sol
@@ -6,10 +6,10 @@ import "@ds-test/test.sol";
 
 import { Staking721 } from "contracts/extension/Staking721.sol";
 import "@openzeppelin/contracts/token/ERC20/ERC20.sol";
-import "@openzeppelin/contracts/token/ERC721/IERC721.sol";
+import "contracts/eip/interface/IERC721.sol";
 import "@openzeppelin/contracts/token/ERC721/IERC721Receiver.sol";
 
-import "../../mocks/MockERC721.sol";
+import { MockERC721 } from "../../mocks/MockERC721.sol";
 
 contract MyStakingContract is ERC20, Staking721, IERC721Receiver {
     bool condition;

--- a/src/test/utils/BaseTest.sol
+++ b/src/test/utils/BaseTest.sol
@@ -29,8 +29,8 @@ import { VoteERC20 } from "contracts/vote/VoteERC20.sol";
 import { SignatureDrop } from "contracts/signature-drop/SignatureDrop.sol";
 import { ContractPublisher } from "contracts/ContractPublisher.sol";
 import { IContractPublisher } from "contracts/interfaces/IContractPublisher.sol";
-import "contracts/airdrop/AirdropERC721.sol";
-import "contracts/airdrop/AirdropERC721Claimable.sol";
+import { AirdropERC721 } from "contracts/airdrop/AirdropERC721.sol";
+import { AirdropERC721Claimable } from "contracts/airdrop/AirdropERC721Claimable.sol";
 import { AirdropERC20 } from "contracts/airdrop/AirdropERC20.sol";
 import "contracts/airdrop/AirdropERC20Claimable.sol";
 import "contracts/airdrop/AirdropERC1155.sol";
@@ -38,7 +38,7 @@ import "contracts/airdrop/AirdropERC1155Claimable.sol";
 import { NFTStake } from "contracts/staking/NFTStake.sol";
 import { EditionStake } from "contracts/staking/EditionStake.sol";
 import { TokenStake } from "contracts/staking/TokenStake.sol";
-import "contracts/mock/Mock.sol";
+import { Mock, MockContract } from "contracts/mock/Mock.sol";
 import "contracts/mock/MockContractPublisher.sol";
 
 abstract contract BaseTest is DSTest, Test {


### PR DESCRIPTION
Now making a release of the contracts npm package with `./release.sh` will not break the SDK and dashboard builds.