### PR TITLE
AccountPermissions: add `setAdminWithSigner`

### DIFF
--- a/contracts/extension/interface/IAccountPermissions.sol
+++ b/contracts/extension/interface/IAccountPermissions.sol
@@ -31,6 +31,14 @@ interface IAccountPermissions {
         bytes32 uid;
     }
 
+    struct AdminPermisionRequest {
+        address account;
+        bool isAdmin;
+        uint128 reqValidityStartTimestamp;
+        uint128 reqValidityEndTimestamp;
+        bytes32 uid;
+    }
+
     /**
      *  @notice The permissions that a signer has to use the smart wallet.
      *
@@ -98,10 +106,15 @@ interface IAccountPermissions {
     function getAllAdmins() external view returns (address[] memory admins);
 
     /// @dev Verifies that a request is signed by an authorized account.
-    function verifySignerPermissionRequest(SignerPermissionRequest calldata req, bytes calldata signature)
-        external
-        view
-        returns (bool success, address signer);
+    function verifySignerPermissionRequest(
+        SignerPermissionRequest calldata req,
+        bytes calldata signature
+    ) external view returns (bool success, address signer);
+
+    function verifyAdminPermissionsRequest(
+        AdminPermisionRequest calldata req,
+        bytes calldata signature
+    ) external view returns (bool success, address signer);
 
     /*///////////////////////////////////////////////////////////////
                             External functions

--- a/contracts/extension/interface/IAccountPermissions.sol
+++ b/contracts/extension/interface/IAccountPermissions.sol
@@ -31,7 +31,7 @@ interface IAccountPermissions {
         bytes32 uid;
     }
 
-    struct AdminPermisionRequest {
+    struct AdminPermissionRequest {
         address account;
         bool isAdmin;
         uint128 reqValidityStartTimestamp;
@@ -106,15 +106,15 @@ interface IAccountPermissions {
     function getAllAdmins() external view returns (address[] memory admins);
 
     /// @dev Verifies that a request is signed by an authorized account.
-    function verifySignerPermissionRequest(
-        SignerPermissionRequest calldata req,
-        bytes calldata signature
-    ) external view returns (bool success, address signer);
+    function verifySignerPermissionRequest(SignerPermissionRequest calldata req, bytes calldata signature)
+        external
+        view
+        returns (bool success, address signer);
 
-    function verifyAdminPermissionsRequest(
-        AdminPermisionRequest calldata req,
-        bytes calldata signature
-    ) external view returns (bool success, address signer);
+    function verifyAdminPermissionsRequest(AdminPermissionRequest calldata req, bytes calldata signature)
+        external
+        view
+        returns (bool success, address signer);
 
     /*///////////////////////////////////////////////////////////////
                             External functions

--- a/contracts/extension/upgradeable/AccountPermissions.sol
+++ b/contracts/extension/upgradeable/AccountPermissions.sol
@@ -59,7 +59,7 @@ abstract contract AccountPermissions is IAccountPermissions, EIP712 {
         _setAdmin(_account, _isAdmin);
     }
 
-    function setAdminWithSigner(AdminPermisionRequest calldata _req, bytes calldata _signature) external {
+    function setAdminWithSigner(AdminPermissionRequest calldata _req, bytes calldata _signature) external {
         address targetAdmin = _req.account;
 
         require(
@@ -148,18 +148,22 @@ abstract contract AccountPermissions is IAccountPermissions, EIP712 {
     }
 
     /// @dev Verifies that a request is signed by an authorized account.
-    function verifySignerPermissionRequest(
-        SignerPermissionRequest calldata req,
-        bytes calldata signature
-    ) public view virtual returns (bool success, address signer) {
+    function verifySignerPermissionRequest(SignerPermissionRequest calldata req, bytes calldata signature)
+        public
+        view
+        virtual
+        returns (bool success, address signer)
+    {
         signer = _recoverAddress(req, signature);
         success = !_accountPermissionsStorage().executed[req.uid] && isAdmin(signer);
     }
 
-    function verifyAdminPermissionsRequest(
-        AdminPermisionRequest calldata req,
-        bytes calldata signature
-    ) public view virtual returns (bool success, address signer) {
+    function verifyAdminPermissionsRequest(AdminPermissionRequest calldata req, bytes calldata signature)
+        public
+        view
+        virtual
+        returns (bool success, address signer)
+    {
         signer = _recoverAddressAdminRequest(req, signature);
         success = !_accountPermissionsStorage().executed[req.uid] && isAdmin(signer);
     }
@@ -247,17 +251,21 @@ abstract contract AccountPermissions is IAccountPermissions, EIP712 {
     }
 
     /// @dev Returns the address of the signer of the request.
-    function _recoverAddress(
-        SignerPermissionRequest calldata _req,
-        bytes calldata _signature
-    ) internal view virtual returns (address) {
+    function _recoverAddress(SignerPermissionRequest calldata _req, bytes calldata _signature)
+        internal
+        view
+        virtual
+        returns (address)
+    {
         return _hashTypedDataV4(keccak256(_encodeRequest(_req))).recover(_signature);
     }
 
-    function _recoverAddressAdminRequest(
-        AdminPermisionRequest calldata _req,
-        bytes calldata _signature
-    ) internal view virtual returns (address) {
+    function _recoverAddressAdminRequest(AdminPermissionRequest calldata _req, bytes calldata _signature)
+        internal
+        view
+        virtual
+        returns (address)
+    {
         return _hashTypedDataV4(keccak256(_encodeRequestAdmin(_req))).recover(_signature);
     }
 
@@ -277,7 +285,7 @@ abstract contract AccountPermissions is IAccountPermissions, EIP712 {
             );
     }
 
-    function _encodeRequestAdmin(AdminPermisionRequest calldata _req) internal pure virtual returns (bytes memory) {
+    function _encodeRequestAdmin(AdminPermissionRequest calldata _req) internal pure virtual returns (bytes memory) {
         return
             abi.encode(
                 TYPEHASH,


### PR DESCRIPTION
This PR add the ability to set an admin with a signer vs requiring `onlyAdmin`. Similar functionality to `setPermissionsForSigner`