### PR TITLE
Fix legacy contract size

### DIFF
--- a/contracts/legacy-contracts/extension/BatchMintMetadata_V1.sol
+++ b/contracts/legacy-contracts/extension/BatchMintMetadata_V1.sol
@@ -1,0 +1,89 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity ^0.8.0;
+
+/// @author thirdweb
+
+/**
+ *  @title   Batch-mint Metadata
+ *  @notice  The `BatchMintMetadata` is a contract extension for any base NFT contract. It lets the smart contract
+ *           using this extension set metadata for `n` number of NFTs all at once. This is enabled by storing a single
+ *           base URI for a batch of `n` NFTs, where the metadata for each NFT in a relevant batch is `baseURI/tokenId`.
+ */
+
+contract BatchMintMetadata_V1 {
+    /// @dev Largest tokenId of each batch of tokens with the same baseURI.
+    uint256[] private batchIds;
+
+    /// @dev Mapping from id of a batch of tokens => to base URI for the respective batch of tokens.
+    mapping(uint256 => string) private baseURI;
+
+    /**
+     *  @notice         Returns the count of batches of NFTs.
+     *  @dev            Each batch of tokens has an in ID and an associated `baseURI`.
+     *                  See {batchIds}.
+     */
+    function getBaseURICount() public view returns (uint256) {
+        return batchIds.length;
+    }
+
+    /**
+     *  @notice         Returns the ID for the batch of tokens at the given index.
+     *  @dev            See {getBaseURICount}.
+     *  @param _index   Index of the desired batch in batchIds array.
+     */
+    function getBatchIdAtIndex(uint256 _index) public view returns (uint256) {
+        if (_index >= getBaseURICount()) {
+            revert("Invalid index");
+        }
+        return batchIds[_index];
+    }
+
+    /// @dev Returns the id for the batch of tokens the given tokenId belongs to.
+    function _getBatchId(uint256 _tokenId) internal view returns (uint256 batchId, uint256 index) {
+        uint256 numOfTokenBatches = getBaseURICount();
+        uint256[] memory indices = batchIds;
+
+        for (uint256 i = 0; i < numOfTokenBatches; i += 1) {
+            if (_tokenId < indices[i]) {
+                index = i;
+                batchId = indices[i];
+
+                return (batchId, index);
+            }
+        }
+
+        revert("Invalid tokenId");
+    }
+
+    /// @dev Returns the baseURI for a token. The intended metadata URI for the token is baseURI + tokenId.
+    function _getBaseURI(uint256 _tokenId) internal view returns (string memory) {
+        uint256 numOfTokenBatches = getBaseURICount();
+        uint256[] memory indices = batchIds;
+
+        for (uint256 i = 0; i < numOfTokenBatches; i += 1) {
+            if (_tokenId < indices[i]) {
+                return baseURI[indices[i]];
+            }
+        }
+        revert("Invalid tokenId");
+    }
+
+    /// @dev Sets the base URI for the batch of tokens with the given batchId.
+    function _setBaseURI(uint256 _batchId, string memory _baseURI) internal {
+        baseURI[_batchId] = _baseURI;
+    }
+
+    /// @dev Mints a batch of tokenIds and associates a common baseURI to all those Ids.
+    function _batchMintMetadata(
+        uint256 _startId,
+        uint256 _amountToMint,
+        string memory _baseURIForTokens
+    ) internal returns (uint256 nextTokenIdToMint, uint256 batchId) {
+        batchId = _startId + _amountToMint;
+        nextTokenIdToMint = batchId;
+
+        batchIds.push(batchId);
+
+        baseURI[batchId] = _baseURIForTokens;
+    }
+}

--- a/contracts/legacy-contracts/extension/LazyMint_V1.sol
+++ b/contracts/legacy-contracts/extension/LazyMint_V1.sol
@@ -1,0 +1,52 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity ^0.8.0;
+
+/// @author thirdweb
+
+import "../../extension/interface/ILazyMint.sol";
+import "./BatchMintMetadata_V1.sol";
+
+/**
+ *  The `LazyMint` is a contract extension for any base NFT contract. It lets you 'lazy mint' any number of NFTs
+ *  at once. Here, 'lazy mint' means defining the metadata for particular tokenIds of your NFT contract, without actually
+ *  minting a non-zero balance of NFTs of those tokenIds.
+ */
+
+abstract contract LazyMint_V1 is ILazyMint, BatchMintMetadata_V1 {
+    /// @notice The tokenId assigned to the next new NFT to be lazy minted.
+    uint256 internal nextTokenIdToLazyMint;
+
+    /**
+     *  @notice                  Lets an authorized address lazy mint a given amount of NFTs.
+     *
+     *  @param _amount           The number of NFTs to lazy mint.
+     *  @param _baseURIForTokens The base URI for the 'n' number of NFTs being lazy minted, where the metadata for each
+     *                           of those NFTs is `${baseURIForTokens}/${tokenId}`.
+     *  @param _data             Additional bytes data to be used at the discretion of the consumer of the contract.
+     *  @return batchId          A unique integer identifier for the batch of NFTs lazy minted together.
+     */
+    function lazyMint(
+        uint256 _amount,
+        string calldata _baseURIForTokens,
+        bytes calldata _data
+    ) public virtual override returns (uint256 batchId) {
+        if (!_canLazyMint()) {
+            revert("Not authorized");
+        }
+
+        if (_amount == 0) {
+            revert("0 amt");
+        }
+
+        uint256 startId = nextTokenIdToLazyMint;
+
+        (nextTokenIdToLazyMint, batchId) = _batchMintMetadata(startId, _amount, _baseURIForTokens);
+
+        emit TokensLazyMinted(startId, startId + _amount - 1, _baseURIForTokens, _data);
+
+        return batchId;
+    }
+
+    /// @dev Returns whether lazy minting can be performed in the given execution context.
+    function _canLazyMint() internal view virtual returns (bool);
+}

--- a/contracts/legacy-contracts/pre-builts/SignatureDrop_V4.sol
+++ b/contracts/legacy-contracts/pre-builts/SignatureDrop_V4.sol
@@ -24,7 +24,7 @@ import "../../extension/Royalty.sol";
 import "../../extension/PrimarySale.sol";
 import "../../extension/Ownable.sol";
 import "../../extension/DelayedReveal.sol";
-import "../../extension/LazyMint.sol";
+import "../extension/LazyMint_V1.sol";
 import "../../extension/PermissionsEnumerable.sol";
 import "../extension/DropSinglePhase_V1.sol";
 import "../../extension/SignatureMintERC721Upgradeable.sol";
@@ -37,7 +37,7 @@ contract SignatureDrop_V4 is
     PrimarySale,
     Ownable,
     DelayedReveal,
-    LazyMint,
+    LazyMint_V1,
     PermissionsEnumerable,
     DropSinglePhase_V1,
     SignatureMintERC721Upgradeable,


### PR DESCRIPTION
Legacy version of lazy-mint and batch-mint-metadata extensions.

To fix SignatureDrop_V4 (legacy) size issue after recent updates to these extensions. 
