### PR TITLE
Modular Accounts

### DIFF
--- a/contracts/prebuilts/account/modular/ModularAccount.sol
+++ b/contracts/prebuilts/account/modular/ModularAccount.sol
@@ -1,0 +1,195 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity ^0.8.11;
+
+/* solhint-disable avoid-low-level-calls */
+/* solhint-disable no-inline-assembly */
+/* solhint-disable reason-string */
+
+// Base
+import "../utils/BaseAccount.sol";
+
+// Extensions
+import "../../../external-deps/openzeppelin/token/ERC721/utils/ERC721Holder.sol";
+import "../../../external-deps/openzeppelin/token/ERC1155/utils/ERC1155Holder.sol";
+import "../../../extension/Initializable.sol";
+
+// Utils
+import "../../../eip/ERC1271.sol";
+import "../utils/Helpers.sol";
+import "../../../external-deps/openzeppelin/utils/cryptography/ECDSA.sol";
+
+import "./Interfaces/IValidator.sol";
+
+import "forge-std/console.sol";
+
+//   $$\     $$\       $$\                 $$\                         $$\
+//   $$ |    $$ |      \__|                $$ |                        $$ |
+// $$$$$$\   $$$$$$$\  $$\  $$$$$$\   $$$$$$$ |$$\  $$\  $$\  $$$$$$\  $$$$$$$\
+// \_$$  _|  $$  __$$\ $$ |$$  __$$\ $$  __$$ |$$ | $$ | $$ |$$  __$$\ $$  __$$\
+//   $$ |    $$ |  $$ |$$ |$$ |  \__|$$ /  $$ |$$ | $$ | $$ |$$$$$$$$ |$$ |  $$ |
+//   $$ |$$\ $$ |  $$ |$$ |$$ |      $$ |  $$ |$$ | $$ | $$ |$$   ____|$$ |  $$ |
+//   \$$$$  |$$ |  $$ |$$ |$$ |      \$$$$$$$ |\$$$$$\$$$$  |\$$$$$$$\ $$$$$$$  |
+//    \____/ \__|  \__|\__|\__|       \_______| \_____\____/  \_______|\_______/
+
+contract ModularAccount is Initializable, ERC1271, ERC721Holder, ERC1155Holder, BaseAccount {
+    using ECDSA for bytes32;
+
+    address public factory;
+    IEntryPoint public immutable entrypointcontract;
+    IValidator public validator;
+
+    /*///////////////////////////////////////////////////////////////
+                    Constructor, Initializer, Modifiers
+    //////////////////////////////////////////////////////////////*/
+
+    constructor(IEntryPoint _entrypoint) {
+        _disableInitializers();
+        entrypointcontract = _entrypoint;
+    }
+
+    function initialize(address /*_defaultAdmin*/, address _factory, bytes calldata _data) public virtual initializer {
+        factory = _factory;
+        (, address _validator) = abi.decode(_data, (address, address));
+        validator = IValidator(_validator);
+        validator.enable(_data);
+    }
+
+    /// @notice Lets the account receive native tokens.
+    receive() external payable {}
+
+    /*///////////////////////////////////////////////////////////////
+                            View functions
+    //////////////////////////////////////////////////////////////*/
+
+    /// @notice See EIP-1271
+    function isValidSignature(
+        bytes32 _hash,
+        bytes calldata _signature
+    ) public view virtual override returns (bytes4 magicValue) {
+        ValidationData memory _validationData = _parseValidationData(validateSignature(_hash, _signature));
+        if (_validationData.validAfter > block.timestamp) revert();
+        if (_validationData.validUntil < block.timestamp) revert();
+        if (_validationData.aggregator != address(0)) revert();
+
+        return MAGICVALUE;
+    }
+
+    function validateSignature(bytes32 hash, bytes calldata signature) public view returns (uint256 validationData) {
+        return _validateSignature(hash, signature);
+    }
+
+    function _validateSignature(bytes32 _hash, bytes calldata _signature) internal view virtual returns (uint256) {
+        return IValidator(validator).validateSignature(_signature, _hash);
+    }
+
+    function _validCaller(address _caller, bytes calldata _data) internal view virtual returns (bool) {
+        return IValidator(validator).validCaller(_caller, _data);
+    }
+
+    /*///////////////////////////////////////////////////////////////
+                            External functions
+    //////////////////////////////////////////////////////////////*/
+
+    /// @notice Executes a transaction (called directly from an admin, or by entryPoint)
+    function execute(address _target, uint256 _value, bytes calldata _calldata) external virtual {
+        _onlyEntryPointOrValidCaller();
+        _call(_target, _value, _calldata);
+    }
+
+    /// @notice Executes a sequence transaction (called directly from an admin, or by entryPoint)
+    function executeBatch(
+        address[] calldata _target,
+        uint256[] calldata _value,
+        bytes[] calldata _calldata
+    ) external virtual {
+        _onlyEntryPointOrValidCaller();
+
+        require(_target.length == _calldata.length && _target.length == _value.length, "Account: wrong array lengths.");
+        for (uint256 i = 0; i < _target.length; i++) {
+            _call(_target[i], _value[i], _calldata[i]);
+        }
+    }
+
+    function _onlyEntryPointOrValidCaller() internal view virtual {
+        if (msg.sender != address(entryPoint()) || !_validCaller(msg.sender, msg.data)) {
+            revert(); //add revert
+        }
+    }
+
+    function setValidator(IValidator _validator) external virtual {
+        if (!_validCaller(msg.sender, msg.data)) {
+            revert(); //add revert
+        }
+        validator = _validator;
+    }
+
+    function addDeposit() public payable {
+        entryPoint().depositTo{ value: msg.value }(address(this));
+    }
+
+    /// @notice Withdraw funds for this account from Entrypoint.
+    function withdrawDepositTo(address payable withdrawAddress, uint256 amount) public {
+        if (!_validCaller(msg.sender, msg.data)) {
+            revert(); //add revert
+        }
+        entryPoint().withdrawTo(withdrawAddress, amount);
+    }
+
+    /*///////////////////////////////////////////////////////////////
+                        Internal functions
+    //////////////////////////////////////////////////////////////*/
+
+    /// @dev Registers the account on the factory if it hasn't been registered yet.
+
+    /// @dev Calls a target contract and reverts if it fails.
+    function _call(
+        address _target,
+        uint256 value,
+        bytes memory _calldata
+    ) internal virtual returns (bytes memory result) {
+        bool success;
+        (success, result) = _target.call{ value: value }(_calldata);
+        if (!success) {
+            assembly {
+                revert(add(result, 32), mload(result))
+            }
+        }
+    }
+
+    function entryPoint() public view virtual override returns (IEntryPoint) {
+        return entrypointcontract;
+    }
+
+    function validateUserOp(
+        UserOperation calldata userOp,
+        bytes32 userOpHash,
+        uint256 missingAccountFunds
+    ) external virtual override returns (uint256 validationData) {
+        _requireFromEntryPoint();
+        validationData = _validateUserOp(userOp, userOpHash, missingAccountFunds);
+        _validateNonce(userOp.nonce);
+        _payPrefund(missingAccountFunds);
+    }
+
+    function _validateSignature(
+        bytes memory signature,
+        bytes32 hash
+    ) internal virtual returns (uint256 validationData) {
+        return validator.validateSignature(signature, hash);
+    }
+
+    function _validateUserOp(
+        UserOperation calldata userOp,
+        bytes32 userOpHash,
+        uint256 missingAccountFunds
+    ) internal virtual returns (uint256 validationData) {
+        return validator.validateUserOp(userOp, userOpHash, missingAccountFunds);
+    }
+
+    function _validateSignature(
+        UserOperation calldata userOp,
+        bytes32 userOpHash
+    ) internal virtual override returns (uint256 validationData) {
+        return validator.validateSignature(userOp.signature, userOpHash);
+    }
+}

--- a/contracts/prebuilts/account/modular/ModularAccountFactory.sol
+++ b/contracts/prebuilts/account/modular/ModularAccountFactory.sol
@@ -1,0 +1,61 @@
+// SPDX-License-Identifier: GPL-3.0
+pragma solidity ^0.8.12;
+
+// Utils
+import "../utils/BaseAccountFactory.sol";
+import "../utils/BaseAccount.sol";
+import "../../../external-deps/openzeppelin/proxy/Clones.sol";
+import "../../../extension/upgradeable/Initializable.sol";
+
+// Extensions
+import "../../../extension/upgradeable//PermissionsEnumerable.sol";
+import "../../../extension/upgradeable//ContractMetadata.sol";
+
+// Interface
+import "../interface/IEntrypoint.sol";
+
+// Smart wallet implementation
+import { ModularAccount } from "./ModularAccount.sol";
+
+//   $$\     $$\       $$\                 $$\                         $$\
+//   $$ |    $$ |      \__|                $$ |                        $$ |
+// $$$$$$\   $$$$$$$\  $$\  $$$$$$\   $$$$$$$ |$$\  $$\  $$\  $$$$$$\  $$$$$$$\
+// \_$$  _|  $$  __$$\ $$ |$$  __$$\ $$  __$$ |$$ | $$ | $$ |$$  __$$\ $$  __$$\
+//   $$ |    $$ |  $$ |$$ |$$ |  \__|$$ /  $$ |$$ | $$ | $$ |$$$$$$$$ |$$ |  $$ |
+//   $$ |$$\ $$ |  $$ |$$ |$$ |      $$ |  $$ |$$ | $$ | $$ |$$   ____|$$ |  $$ |
+//   \$$$$  |$$ |  $$ |$$ |$$ |      \$$$$$$$ |\$$$$$\$$$$  |\$$$$$$$\ $$$$$$$  |
+//    \____/ \__|  \__|\__|\__|       \_______| \_____\____/  \_______|\_______/
+
+contract ModularAccountFactory is Initializable, BaseAccountFactory, ContractMetadata, PermissionsEnumerable {
+    /*///////////////////////////////////////////////////////////////
+                            Constructor
+    //////////////////////////////////////////////////////////////*/
+
+    constructor(IEntryPoint _entrypoint) BaseAccountFactory(address(new ModularAccount(_entrypoint)), address(_entrypoint)) {
+        _disableInitializers();
+    }
+
+    /// @notice Initializes the factory contract.
+    function initialize(address _defaultAdmin, string memory _contractURI) external initializer {
+        _setupRole(DEFAULT_ADMIN_ROLE, _defaultAdmin);
+        _setupContractURI(_contractURI);
+    }
+
+    /*///////////////////////////////////////////////////////////////
+                        Internal functions
+    //////////////////////////////////////////////////////////////*/
+
+    /// @dev Called in `createAccount`. Initializes the account contract created in `createAccount`.
+    function _initializeAccount(
+        address _account,
+        address _admin,
+        bytes calldata _data
+    ) internal override {
+        ModularAccount(payable(_account)).initialize(_admin, address(this), _data);
+    }
+
+    /// @dev Returns whether contract metadata can be set in the given execution context.
+    function _canSetContractURI() internal view virtual override returns (bool) {
+        return hasRole(DEFAULT_ADMIN_ROLE, msg.sender);
+    }
+}

--- a/contracts/prebuilts/account/modular/ModularAccountFactory.sol
+++ b/contracts/prebuilts/account/modular/ModularAccountFactory.sol
@@ -31,7 +31,9 @@ contract ModularAccountFactory is Initializable, BaseAccountFactory, ContractMet
                             Constructor
     //////////////////////////////////////////////////////////////*/
 
-    constructor(IEntryPoint _entrypoint) BaseAccountFactory(address(new ModularAccount(_entrypoint)), address(_entrypoint)) {
+    constructor(address _entrypoint)
+        BaseAccountFactory(address(new ModularAccount(IEntryPoint(_entrypoint))), _entrypoint)
+    {
         _disableInitializers();
     }
 

--- a/contracts/prebuilts/account/modular/ModularAccountStorage.sol
+++ b/contracts/prebuilts/account/modular/ModularAccountStorage.sol
@@ -1,0 +1,23 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity ^0.8.11;
+
+library ModularAccountStorage {
+    /// @custom:storage-location erc7201:modular.account.storage
+    /// @dev keccak256(abi.encode(uint256(keccak256("modular.account.storage")) - 1)) & ~bytes32(uint256(0xff))
+    bytes32 public constant MODULAR_ACCOUNT_STORAGE_POSITION =
+        0x858d12b8662f5371f269308912750e6d1d8e3f2e07a9479e78bb47537cfdf800;
+
+    struct Data {
+        address factory;
+        address entrypointContract;
+        address validator;
+        bytes32 creationSalt;
+    }
+
+    function data() internal pure returns (Data storage modularAccountData) {
+        bytes32 position = MODULAR_ACCOUNT_STORAGE_POSITION;
+        assembly {
+            modularAccountData.slot := position
+        }
+    }
+}

--- a/contracts/prebuilts/account/modular/interfaces/IModularAccount.sol
+++ b/contracts/prebuilts/account/modular/interfaces/IModularAccount.sol
@@ -1,0 +1,25 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+import "../../utils/UserOperation.sol";
+import "../../interface/IAccount.sol";
+
+interface IModularAccount is IAccount {
+    event ValidatorUpdated(address indexed priorValidator, address indexed newValidator);
+
+    function execute(
+        address _target,
+        uint256 _value,
+        bytes calldata _calldata
+    ) external;
+
+    function executeBatch(
+        address[] calldata _target,
+        uint256[] calldata _value,
+        bytes[] calldata _calldata
+    ) external;
+
+    function setValidator(address _validator) external;
+
+    function updateSignerOnFactory(address _signer, bool _status) external;
+}

--- a/contracts/prebuilts/account/modular/interfaces/IValidator.sol
+++ b/contracts/prebuilts/account/modular/interfaces/IValidator.sol
@@ -4,11 +4,9 @@ pragma solidity ^0.8.0;
 import "../../utils/UserOperation.sol";
 
 interface IValidator {
-    error NotImplemented();
+    function activate(bytes calldata _data) external payable;
 
-    function enable(bytes calldata _data) external payable;
-
-    function disable(bytes calldata _data) external payable;
+    function deactivate(bytes calldata _data) external payable;
 
     function validateUserOp(
         UserOperation calldata userOp,
@@ -17,4 +15,6 @@ interface IValidator {
     ) external payable returns (uint256);
 
     function validateSignature(bytes calldata signature, bytes32 hash) external view returns (uint256);
+
+    function validateCaller(address caller, bytes calldata data) external view returns (bool);
 }

--- a/contracts/prebuilts/account/modular/interfaces/IValidator.sol
+++ b/contracts/prebuilts/account/modular/interfaces/IValidator.sol
@@ -1,0 +1,20 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+import "../../utils/UserOperation.sol";
+
+interface IValidator {
+    error NotImplemented();
+
+    function enable(bytes calldata _data) external payable;
+
+    function disable(bytes calldata _data) external payable;
+
+    function validateUserOp(
+        UserOperation calldata userOp,
+        bytes32 userOpHash,
+        uint256 missingAccountFunds
+    ) external payable returns (uint256);
+
+    function validateSignature(bytes calldata signature, bytes32 hash) external view returns (uint256);
+}

--- a/contracts/prebuilts/account/modular/plugins/validation/SingleOwnerValidator.sol
+++ b/contracts/prebuilts/account/modular/plugins/validation/SingleOwnerValidator.sol
@@ -5,11 +5,25 @@ pragma solidity ^0.8.0;
 import "../../../utils/UserOperation.sol";
 import "../../../../../external-deps/openzeppelin/utils/cryptography/ECDSA.sol";
 import "../../Interfaces/IValidator.sol";
-
 import "../../../utils/Helpers.sol";
+import "../../interfaces/IModularAccount.sol";
 
-struct SingleOwnerValidatorStorage {
-    address owner;
+library SingleOwnerValidatorStorage {
+    /// @custom:storage-location erc7201:single.owner.validator.storage
+    /// @dev keccak256(abi.encode(uint256(keccak256("single.owner.validator.storage")) - 1)) & ~bytes32(uint256(0xff))
+    bytes32 public constant SINGLE_OWNER_VALIDATOR_STORAGE_POSITION =
+        0xaf195a59902847d4a0aaedbe0f074e12c4ddcb98a2c64578c15adc5c7fb3de00;
+
+    struct Data {
+        mapping(address => address) owner;
+    }
+
+    function data() internal pure returns (Data storage singleOwnerValidatorData) {
+        bytes32 position = SINGLE_OWNER_VALIDATOR_STORAGE_POSITION;
+        assembly {
+            singleOwnerValidatorData.slot := position
+        }
+    }
 }
 
 contract SingleOwnerValidator is IValidator {
@@ -17,16 +31,15 @@ contract SingleOwnerValidator is IValidator {
 
     event OwnerUpdated(address indexed account, address indexed oldOwner, address indexed newOwner);
 
-    mapping(address => SingleOwnerValidatorStorage) public singleOwnerValidatorStorage;
-
-    function disable(bytes calldata) external payable override {
-        delete singleOwnerValidatorStorage[msg.sender];
+    function deactivate(bytes calldata) external payable override {
+        delete SingleOwnerValidatorStorage.data().owner[msg.sender];
     }
 
-    function enable(bytes calldata _data) external payable override {
+    function activate(bytes calldata _data) external payable override {
         (address owner, ) = abi.decode(_data, (address, address));
-        address prevOwner = singleOwnerValidatorStorage[msg.sender].owner;
-        singleOwnerValidatorStorage[msg.sender].owner = owner;
+        address prevOwner = SingleOwnerValidatorStorage.data().owner[msg.sender];
+        SingleOwnerValidatorStorage.data().owner[msg.sender] = owner;
+        IModularAccount(msg.sender).updateSignerOnFactory(owner, true);
         emit OwnerUpdated(msg.sender, prevOwner, owner);
     }
 
@@ -38,7 +51,7 @@ contract SingleOwnerValidator is IValidator {
         bytes32 hash = _userOpHash.toEthSignedMessageHash();
         address signer = hash.recover(_userOp.signature);
 
-        if (singleOwnerValidatorStorage[msg.sender].owner != signer) {
+        if (SingleOwnerValidatorStorage.data().owner[msg.sender] != signer) {
             return 1;
         }
 
@@ -46,12 +59,24 @@ contract SingleOwnerValidator is IValidator {
     }
 
     function validateSignature(bytes calldata signature, bytes32 hash) public view override returns (uint256) {
-        address owner = singleOwnerValidatorStorage[msg.sender].owner;
+        address owner = SingleOwnerValidatorStorage.data().owner[msg.sender];
 
         address signer = hash.recover(signature);
 
         if (owner != signer) return 1;
 
         return _packValidationData(ValidationData(address(0), uint48(0), type(uint48).max));
+    }
+
+    function validateCaller(address caller, bytes calldata) external view override returns (bool) {
+        return SingleOwnerValidatorStorage.data().owner[msg.sender] == caller;
+    }
+
+    function updateOwner(address _newOwner) external {
+        address prevOwner = SingleOwnerValidatorStorage.data().owner[msg.sender];
+        SingleOwnerValidatorStorage.data().owner[msg.sender] = _newOwner;
+        IModularAccount(msg.sender).updateSignerOnFactory(_newOwner, true);
+        IModularAccount(msg.sender).updateSignerOnFactory(prevOwner, false);
+        emit OwnerUpdated(msg.sender, prevOwner, _newOwner);
     }
 }

--- a/contracts/prebuilts/account/modular/plugins/validation/SingleOwnerValidator.sol
+++ b/contracts/prebuilts/account/modular/plugins/validation/SingleOwnerValidator.sol
@@ -1,0 +1,57 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.8.0;
+
+import "../../../utils/UserOperation.sol";
+import "../../../../../external-deps/openzeppelin/utils/cryptography/ECDSA.sol";
+import "../../Interfaces/IValidator.sol";
+
+import "../../../utils/Helpers.sol";
+
+struct SingleOwnerValidatorStorage {
+    address owner;
+}
+
+contract SingleOwnerValidator is IValidator {
+    using ECDSA for bytes32;
+
+    event OwnerUpdated(address indexed account, address indexed oldOwner, address indexed newOwner);
+
+    mapping(address => SingleOwnerValidatorStorage) public singleOwnerValidatorStorage;
+
+    function disable(bytes calldata) external payable override {
+        delete singleOwnerValidatorStorage[msg.sender];
+    }
+
+    function enable(bytes calldata _data) external payable override {
+        (address owner, ) = abi.decode(_data, (address, address));
+        address prevOwner = singleOwnerValidatorStorage[msg.sender].owner;
+        singleOwnerValidatorStorage[msg.sender].owner = owner;
+        emit OwnerUpdated(msg.sender, prevOwner, owner);
+    }
+
+    function validateUserOp(
+        UserOperation calldata _userOp,
+        bytes32 _userOpHash,
+        uint256
+    ) external payable override returns (uint256) {
+        bytes32 hash = _userOpHash.toEthSignedMessageHash();
+        address signer = hash.recover(_userOp.signature);
+
+        if (singleOwnerValidatorStorage[msg.sender].owner != signer) {
+            return 1;
+        }
+
+        return _packValidationData(ValidationData(address(0), uint48(0), type(uint48).max));
+    }
+
+    function validateSignature(bytes calldata signature, bytes32 hash) public view override returns (uint256) {
+        address owner = singleOwnerValidatorStorage[msg.sender].owner;
+
+        address signer = hash.recover(signature);
+
+        if (owner != signer) return 1;
+
+        return _packValidationData(ValidationData(address(0), uint48(0), type(uint48).max));
+    }
+}

--- a/src/test/smart-wallet/ModularAccount.t.sol
+++ b/src/test/smart-wallet/ModularAccount.t.sol
@@ -1,0 +1,832 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity ^0.8.0;
+
+// Test utils
+import "../utils/BaseTest.sol";
+import { TWProxy } from "contracts/infra/TWProxy.sol";
+
+// Account Abstraction setup for smart wallets.
+import { EntryPoint, IEntryPoint } from "contracts/prebuilts/account/utils/Entrypoint.sol";
+import { UserOperation } from "contracts/prebuilts/account/utils/UserOperation.sol";
+
+// Target
+import { IAccountPermissions } from "contracts/extension/interface/IAccountPermissions.sol";
+import { ModularAccountFactory } from "contracts/prebuilts/account/modular/ModularAccountFactory.sol";
+import { ModularAccount } from "contracts/prebuilts/account/modular/ModularAccount.sol";
+import { SingleOwnerValidator } from "contracts/prebuilts/account/modular/plugins/validation/SingleOwnerValidator.sol";
+
+/// @dev This is a dummy contract to test contract interactions with Account.
+contract Number {
+    uint256 public num;
+
+    function setNum(uint256 _num) public {
+        num = _num;
+    }
+
+    function doubleNum() public {
+        num *= 2;
+    }
+
+    function incrementNum() public {
+        num += 1;
+    }
+}
+
+contract ModularAccounTest is BaseTest {
+    // Target contracts
+    EntryPoint private entrypoint;
+    ModularAccountFactory private accountFactory;
+    SingleOwnerValidator private validator;
+
+    // Mocks
+    Number internal numberContract;
+
+    // Test params
+    uint256 private accountAdminPKey = 100;
+    address private accountAdmin;
+
+    uint256 private accountSignerPKey = 200;
+    address private accountSigner;
+
+    uint256 private nonSignerPKey = 300;
+    address private nonSigner;
+
+    // UserOp terminology: `sender` is the smart wallet.
+    address private sender = 0xd9E938fa9B0D65de58bdC1B88832b3E46c300795;
+    address payable private beneficiary = payable(address(0x45654));
+
+    bytes32 private uidCache = bytes32("random uid");
+
+    address internal factoryImpl;
+
+    event AccountCreated(address indexed account, address indexed accountAdmin);
+
+    function _prepareSignature(
+        IAccountPermissions.SignerPermissionRequest memory _req
+    ) internal view returns (bytes32 typedDataHash) {
+        bytes32 typehashSignerPermissionRequest = keccak256(
+            "SignerPermissionRequest(address signer,uint8 isAdmin,address[] approvedTargets,uint256 nativeTokenLimitPerTransaction,uint128 permissionStartTimestamp,uint128 permissionEndTimestamp,uint128 reqValidityStartTimestamp,uint128 reqValidityEndTimestamp,bytes32 uid)"
+        );
+        bytes32 nameHash = keccak256(bytes("Account"));
+        bytes32 versionHash = keccak256(bytes("1"));
+        bytes32 typehashEip712 = keccak256(
+            "EIP712Domain(string name,string version,uint256 chainId,address verifyingContract)"
+        );
+        bytes32 domainSeparator = keccak256(abi.encode(typehashEip712, nameHash, versionHash, block.chainid, sender));
+
+        bytes memory encodedRequestStart = abi.encode(
+            typehashSignerPermissionRequest,
+            _req.signer,
+            _req.isAdmin,
+            keccak256(abi.encodePacked(_req.approvedTargets)),
+            _req.nativeTokenLimitPerTransaction
+        );
+
+        bytes memory encodedRequestEnd = abi.encode(
+            _req.permissionStartTimestamp,
+            _req.permissionEndTimestamp,
+            _req.reqValidityStartTimestamp,
+            _req.reqValidityEndTimestamp,
+            _req.uid
+        );
+
+        bytes32 structHash = keccak256(bytes.concat(encodedRequestStart, encodedRequestEnd));
+        typedDataHash = keccak256(abi.encodePacked("\x19\x01", domainSeparator, structHash));
+    }
+
+    function _signSignerPermissionRequest(
+        IAccountPermissions.SignerPermissionRequest memory _req
+    ) internal view returns (bytes memory signature) {
+        bytes32 typedDataHash = _prepareSignature(_req);
+        (uint8 v, bytes32 r, bytes32 s) = vm.sign(accountAdminPKey, typedDataHash);
+        signature = abi.encodePacked(r, s, v);
+    }
+
+    function _setupUserOp(
+        uint256 _signerPKey,
+        bytes memory _initCode,
+        bytes memory _callDataForEntrypoint
+    ) internal returns (UserOperation[] memory ops) {
+        uint256 nonce = entrypoint.getNonce(sender, 0);
+
+        // Get user op fields
+        UserOperation memory op = UserOperation({
+            sender: sender,
+            nonce: nonce,
+            initCode: _initCode,
+            callData: _callDataForEntrypoint,
+            callGasLimit: 500_000,
+            verificationGasLimit: 500_000,
+            preVerificationGas: 500_000,
+            maxFeePerGas: 0,
+            maxPriorityFeePerGas: 0,
+            paymasterAndData: bytes(""),
+            signature: bytes("")
+        });
+
+        // Sign UserOp
+        bytes32 opHash = EntryPoint(entrypoint).getUserOpHash(op);
+        bytes32 msgHash = ECDSA.toEthSignedMessageHash(opHash);
+
+        (uint8 v, bytes32 r, bytes32 s) = vm.sign(_signerPKey, msgHash);
+        bytes memory userOpSignature = abi.encodePacked(r, s, v);
+
+        address recoveredSigner = ECDSA.recover(msgHash, v, r, s);
+        address expectedSigner = vm.addr(_signerPKey);
+        assertEq(recoveredSigner, expectedSigner);
+
+        op.signature = userOpSignature;
+
+        // Store UserOp
+        ops = new UserOperation[](1);
+        ops[0] = op;
+    }
+
+    function _setupUserOpWithSender(
+        bytes memory _initCode,
+        bytes memory _callDataForEntrypoint,
+        address _sender
+    ) internal returns (UserOperation[] memory ops) {
+        uint256 nonce = entrypoint.getNonce(_sender, 0);
+
+        // Get user op fields
+        UserOperation memory op = UserOperation({
+            sender: _sender,
+            nonce: nonce,
+            initCode: _initCode,
+            callData: _callDataForEntrypoint,
+            callGasLimit: 500_000,
+            verificationGasLimit: 500_000,
+            preVerificationGas: 500_000,
+            maxFeePerGas: 0,
+            maxPriorityFeePerGas: 0,
+            paymasterAndData: bytes(""),
+            signature: bytes("")
+        });
+
+        // Sign UserOp
+        bytes32 opHash = EntryPoint(entrypoint).getUserOpHash(op);
+        bytes32 msgHash = ECDSA.toEthSignedMessageHash(opHash);
+
+        (uint8 v, bytes32 r, bytes32 s) = vm.sign(accountAdminPKey, msgHash);
+        bytes memory userOpSignature = abi.encodePacked(r, s, v);
+
+        address recoveredSigner = ECDSA.recover(msgHash, v, r, s);
+        address expectedSigner = vm.addr(accountAdminPKey);
+        assertEq(recoveredSigner, expectedSigner);
+
+        op.signature = userOpSignature;
+
+        // Store UserOp
+        ops = new UserOperation[](1);
+        ops[0] = op;
+    }
+
+    function _setupUserOpExecuteWithSender(
+        bytes memory _initCode,
+        address _target,
+        uint256 _value,
+        bytes memory _callData,
+        address _sender
+    ) internal returns (UserOperation[] memory) {
+        bytes memory callDataForEntrypoint = abi.encodeWithSignature(
+            "execute(address,uint256,bytes)",
+            _target,
+            _value,
+            _callData
+        );
+
+        return _setupUserOpWithSender(_initCode, callDataForEntrypoint, _sender);
+    }
+
+    function _setupUserOpExecute(
+        uint256 _signerPKey,
+        bytes memory _initCode,
+        address _target,
+        uint256 _value,
+        bytes memory _callData
+    ) internal returns (UserOperation[] memory) {
+        bytes memory callDataForEntrypoint = abi.encodeWithSignature(
+            "execute(address,uint256,bytes)",
+            _target,
+            _value,
+            _callData
+        );
+
+        return _setupUserOp(_signerPKey, _initCode, callDataForEntrypoint);
+    }
+
+    function _setupUserOpExecuteBatch(
+        uint256 _signerPKey,
+        bytes memory _initCode,
+        address[] memory _target,
+        uint256[] memory _value,
+        bytes[] memory _callData
+    ) internal returns (UserOperation[] memory) {
+        bytes memory callDataForEntrypoint = abi.encodeWithSignature(
+            "executeBatch(address[],uint256[],bytes[])",
+            _target,
+            _value,
+            _callData
+        );
+
+        return _setupUserOp(_signerPKey, _initCode, callDataForEntrypoint);
+    }
+
+    /// @dev Returns the salt used when deploying an Account.
+    function _generateSalt(address _admin, bytes memory _data) internal view virtual returns (bytes32) {
+        return keccak256(abi.encode(_admin, _data));
+    }
+
+    function setUp() public override {
+        super.setUp();
+
+        // Setup signers.
+        accountAdmin = vm.addr(accountAdminPKey);
+        vm.deal(accountAdmin, 100 ether);
+
+        accountSigner = vm.addr(accountSignerPKey);
+        nonSigner = vm.addr(nonSignerPKey);
+
+        // Setup contracts
+        entrypoint = new EntryPoint();
+
+        validator = new SingleOwnerValidator();
+        // deploy account factory
+        factoryImpl = address(new ModularAccountFactory(IEntryPoint(payable(address(entrypoint)))));
+        accountFactory = ModularAccountFactory(
+            address(
+                payable(
+                    new TWProxy(
+                        factoryImpl,
+                        abi.encodeWithSignature("initialize(address,string)", deployer, "https://example.com")
+                    )
+                )
+            )
+        );
+        // deploy dummy contract
+        numberContract = new Number();
+    }
+
+    /*///////////////////////////////////////////////////////////////
+                        Test: initial state
+    //////////////////////////////////////////////////////////////*/
+
+    function test_initialState() external {
+        assertEq(accountFactory.entrypoint(), address(entrypoint));
+        assertEq(accountFactory.contractURI(), "https://example.com");
+        assertEq(accountFactory.hasRole(0x00, deployer), true);
+    }
+
+    function test_revert_initializeImplementation() public {
+        vm.expectRevert("Initializable: contract is already initialized");
+        ModularAccountFactory(factoryImpl).initialize(deployer, "https://example.com");
+    }
+
+    /*///////////////////////////////////////////////////////////////
+                        Test: creating an account
+    //////////////////////////////////////////////////////////////*/
+
+    /// @dev Create an account by directly calling the factory.
+    function test_state_createAccount_viaFactory() public {
+        bytes memory initData = abi.encode(accountAdmin, address(validator));
+
+        vm.expectEmit(true, true, false, true);
+        emit AccountCreated(sender, accountAdmin);
+        accountFactory.createAccount(accountAdmin, initData);
+
+        address[] memory allAccounts = accountFactory.getAllAccounts();
+        assertEq(allAccounts.length, 1);
+        assertEq(allAccounts[0], sender);
+    }
+
+    /// @dev Create an account via Entrypoint.
+    function test_state_createAccount_viaEntrypointSingle() public {
+        bytes memory initData = abi.encode(accountAdmin, address(validator));
+
+        bytes memory initCallData = abi.encodeWithSignature("createAccount(address,bytes)", accountAdmin, initData);
+        bytes memory initCode = abi.encodePacked(abi.encodePacked(address(accountFactory)), initCallData);
+
+        UserOperation[] memory userOpCreateAccount = _setupUserOpExecute(
+            accountAdminPKey,
+            initCode,
+            address(0),
+            0,
+            bytes("")
+        );
+
+        vm.expectEmit(true, true, false, true);
+        emit AccountCreated(sender, accountAdmin);
+        EntryPoint(entrypoint).handleOps(userOpCreateAccount, beneficiary);
+
+        address[] memory allAccounts = accountFactory.getAllAccounts();
+        assertEq(allAccounts.length, 1);
+        assertEq(allAccounts[0], sender);
+    }
+
+        /// @dev Try registering with factory with a contract not deployed by factory.
+        function test_revert_onRegister_nonFactoryChildContract() public {
+            vm.prank(address(0x12345));
+            vm.expectRevert("AccountFactory: not an account.");
+            accountFactory.onRegister(_generateSalt(accountAdmin, ""));
+        }
+
+        // /// @dev Create more than one accounts with the same admin.
+        // function test_state_createAccount_viaEntrypoint_multipleAccountSameAdmin() public {
+        //     uint256 start = 0;
+        //     uint256 end = 0;
+
+        //     assertEq(accountFactory.totalAccounts(), 0);
+
+        //     vm.expectRevert("BaseAccountFactory: invalid indices");
+        //     address[] memory accs = accountFactory.getAccounts(start, end);
+
+        //     uint256 amount = 100;
+
+        //     for (uint256 i = 0; i < amount; i += 1) {
+        //         bytes memory initCallData = abi.encodeWithSignature(
+        //             "createAccount(address,bytes)",
+        //             accountAdmin,
+        //             bytes(abi.encode(i))
+        //         );
+        //         bytes memory initCode = abi.encodePacked(abi.encodePacked(address(accountFactory)), initCallData);
+
+        //         address expectedSenderAddress = Clones.predictDeterministicAddress(
+        //             accountFactory.accountImplementation(),
+        //             _generateSalt(accountAdmin, bytes(abi.encode(i))),
+        //             address(accountFactory)
+        //         );
+
+        //         UserOperation[] memory userOpCreateAccount = _setupUserOpExecuteWithSender(
+        //             initCode,
+        //             address(0),
+        //             0,
+        //             bytes(abi.encode(i)),
+        //             expectedSenderAddress
+        //         );
+
+        //         vm.expectEmit(true, true, false, true);
+        //         emit AccountCreated(expectedSenderAddress, accountAdmin);
+        //         EntryPoint(entrypoint).handleOps(userOpCreateAccount, beneficiary);
+        //     }
+
+        //     address[] memory allAccounts = accountFactory.getAllAccounts();
+        //     assertEq(allAccounts.length, amount);
+        //     assertEq(accountFactory.totalAccounts(), amount);
+
+        //     for (uint256 i = 0; i < amount; i += 1) {
+        //         assertEq(
+        //             allAccounts[i],
+        //             Clones.predictDeterministicAddress(
+        //                 accountFactory.accountImplementation(),
+        //                 _generateSalt(accountAdmin, bytes(abi.encode(i))),
+        //                 address(accountFactory)
+        //             )
+        //         );
+        //     }
+
+        //     start = 25;
+        //     end = 75;
+
+        //     address[] memory accountsPaginatedOne = accountFactory.getAccounts(start, end);
+
+        //     for (uint256 i = 0; i < (end - start); i += 1) {
+        //         assertEq(
+        //             accountsPaginatedOne[i],
+        //             Clones.predictDeterministicAddress(
+        //                 accountFactory.accountImplementation(),
+        //                 _generateSalt(accountAdmin, bytes(abi.encode(start + i))),
+        //                 address(accountFactory)
+        //             )
+        //         );
+        //     }
+
+        //     start = 0;
+        //     end = amount;
+
+        //     address[] memory accountsPaginatedTwo = accountFactory.getAccounts(start, end);
+
+        //     for (uint256 i = 0; i < (end - start); i += 1) {
+        //         assertEq(
+        //             accountsPaginatedTwo[i],
+        //             Clones.predictDeterministicAddress(
+        //                 accountFactory.accountImplementation(),
+        //                 _generateSalt(accountAdmin, bytes(abi.encode(start + i))),
+        //                 address(accountFactory)
+        //             )
+        //         );
+        //     }
+
+        //     start = 75;
+        //     end = 25;
+
+        //     vm.expectRevert("BaseAccountFactory: invalid indices");
+        //     accs = accountFactory.getAccounts(start, end);
+
+        //     start = 25;
+        //     end = amount + 1;
+
+        //     vm.expectRevert("BaseAccountFactory: invalid indices");
+        //     accs = accountFactory.getAccounts(start, end);
+        // }
+
+    //     /*///////////////////////////////////////////////////////////////
+    //                     Test: performing a contract call
+    //     //////////////////////////////////////////////////////////////*/
+
+    //     function _setup_executeTransaction() internal {
+    //         bytes memory initCallData = abi.encodeWithSignature("createAccount(address,bytes)", accountAdmin, bytes(""));
+    //         bytes memory initCode = abi.encodePacked(abi.encodePacked(address(accountFactory)), initCallData);
+
+    //         UserOperation[] memory userOpCreateAccount = _setupUserOpExecute(
+    //             accountAdminPKey,
+    //             initCode,
+    //             address(0),
+    //             0,
+    //             bytes("")
+    //         );
+
+    //         EntryPoint(entrypoint).handleOps(userOpCreateAccount, beneficiary);
+    //     }
+
+    //     /// @dev Perform a state changing transaction directly via account.
+    //     function test_state_executeTransaction() public {
+    //         _setup_executeTransaction();
+
+    //         address account = accountFactory.getAddress(accountAdmin, bytes(""));
+
+    //         assertEq(numberContract.num(), 0);
+
+    //         vm.prank(accountAdmin);
+    //         ModularAccount(payable(account)).execute(
+    //             address(numberContract),
+    //             0,
+    //             abi.encodeWithSignature("setNum(uint256)", 42)
+    //         );
+
+    //         assertEq(numberContract.num(), 42);
+    //     }
+
+    //     /// @dev Perform many state changing transactions in a batch directly via account.
+    //     function test_state_executeBatchTransaction() public {
+    //         _setup_executeTransaction();
+
+    //         address account = accountFactory.getAddress(accountAdmin, bytes(""));
+
+    //         assertEq(numberContract.num(), 0);
+
+    //         uint256 count = 3;
+    //         address[] memory targets = new address[](count);
+    //         uint256[] memory values = new uint256[](count);
+    //         bytes[] memory callData = new bytes[](count);
+
+    //         for (uint256 i = 0; i < count; i += 1) {
+    //             targets[i] = address(numberContract);
+    //             values[i] = 0;
+    //             callData[i] = abi.encodeWithSignature("incrementNum()", i);
+    //         }
+
+    //         vm.prank(accountAdmin);
+    //         ModularAccount(payable(account)).executeBatch(targets, values, callData);
+
+    //         assertEq(numberContract.num(), count);
+    //     }
+
+    //     /// @dev Perform a state changing transaction via Entrypoint.
+    //     function test_state_executeTransaction_viaEntrypoint() public {
+    //         _setup_executeTransaction();
+
+    //         assertEq(numberContract.num(), 0);
+
+    //         UserOperation[] memory userOp = _setupUserOpExecute(
+    //             accountAdminPKey,
+    //             bytes(""),
+    //             address(numberContract),
+    //             0,
+    //             abi.encodeWithSignature("setNum(uint256)", 42)
+    //         );
+
+    //         EntryPoint(entrypoint).handleOps(userOp, beneficiary);
+
+    //         assertEq(numberContract.num(), 42);
+    //     }
+
+    //     /// @dev Perform many state changing transactions in a batch via Entrypoint.
+    //     function test_state_executeBatchTransaction_viaEntrypoint() public {
+    //         _setup_executeTransaction();
+
+    //         assertEq(numberContract.num(), 0);
+
+    //         uint256 count = 3;
+    //         address[] memory targets = new address[](count);
+    //         uint256[] memory values = new uint256[](count);
+    //         bytes[] memory callData = new bytes[](count);
+
+    //         for (uint256 i = 0; i < count; i += 1) {
+    //             targets[i] = address(numberContract);
+    //             values[i] = 0;
+    //             callData[i] = abi.encodeWithSignature("incrementNum()", i);
+    //         }
+
+    //         UserOperation[] memory userOp = _setupUserOpExecuteBatch(
+    //             accountAdminPKey,
+    //             bytes(""),
+    //             targets,
+    //             values,
+    //             callData
+    //         );
+
+    //         EntryPoint(entrypoint).handleOps(userOp, beneficiary);
+
+    //         assertEq(numberContract.num(), count);
+    //     }
+
+    //     /// @dev Perform many state changing transactions in a batch via Entrypoint.
+    //     function test_state_executeBatchTransaction_viaAccountSigner() public {
+    //         _setup_executeTransaction();
+
+    //         assertEq(numberContract.num(), 0);
+
+    //         uint256 count = 3;
+    //         address[] memory targets = new address[](count);
+    //         uint256[] memory values = new uint256[](count);
+    //         bytes[] memory callData = new bytes[](count);
+
+    //         for (uint256 i = 0; i < count; i += 1) {
+    //             targets[i] = address(numberContract);
+    //             values[i] = 0;
+    //             callData[i] = abi.encodeWithSignature("incrementNum()", i);
+    //         }
+
+    //         address account = accountFactory.getAddress(accountAdmin, bytes(""));
+
+    //         address[] memory approvedTargets = new address[](1);
+    //         approvedTargets[0] = address(numberContract);
+
+    //         IAccountPermissions.SignerPermissionRequest memory permissionsReq = IAccountPermissions.SignerPermissionRequest(
+    //             accountSigner,
+    //             0,
+    //             approvedTargets,
+    //             1 ether,
+    //             0,
+    //             type(uint128).max,
+    //             0,
+    //             type(uint128).max,
+    //             uidCache
+    //         );
+
+    //         vm.prank(accountAdmin);
+    //         bytes memory sig = _signSignerPermissionRequest(permissionsReq);
+    //         ModularAccount(payable(account)).setPermissionsForSigner(permissionsReq, sig);
+
+    //         UserOperation[] memory userOp = _setupUserOpExecuteBatch(
+    //             accountSignerPKey,
+    //             bytes(""),
+    //             targets,
+    //             values,
+    //             callData
+    //         );
+
+    //         EntryPoint(entrypoint).handleOps(userOp, beneficiary);
+
+    //         assertEq(numberContract.num(), count);
+    //     }
+
+    //     /// @dev Perform a state changing transaction via Entrypoint and a SIGNER_ROLE holder.
+    //     function test_state_executeTransaction_viaAccountSigner() public {
+    //         _setup_executeTransaction();
+
+    //         address account = accountFactory.getAddress(accountAdmin, bytes(""));
+
+    //         address[] memory approvedTargets = new address[](1);
+    //         approvedTargets[0] = address(numberContract);
+
+    //         IAccountPermissions.SignerPermissionRequest memory permissionsReq = IAccountPermissions.SignerPermissionRequest(
+    //             accountSigner,
+    //             0,
+    //             approvedTargets,
+    //             1 ether,
+    //             0,
+    //             type(uint128).max,
+    //             0,
+    //             type(uint128).max,
+    //             uidCache
+    //         );
+
+    //         vm.prank(accountAdmin);
+    //         bytes memory sig = _signSignerPermissionRequest(permissionsReq);
+    //         ModularAccount(payable(account)).setPermissionsForSigner(permissionsReq, sig);
+
+    //         assertEq(numberContract.num(), 0);
+
+    //         UserOperation[] memory userOp = _setupUserOpExecute(
+    //             accountSignerPKey,
+    //             bytes(""),
+    //             address(numberContract),
+    //             0,
+    //             abi.encodeWithSignature("setNum(uint256)", 42)
+    //         );
+
+    //         EntryPoint(entrypoint).handleOps(userOp, beneficiary);
+
+    //         assertEq(numberContract.num(), 42);
+    //     }
+
+    //     /// @dev Revert: perform a state changing transaction via Entrypoint without appropriate permissions.
+    //     function test_revert_executeTransaction_nonSigner_viaEntrypoint() public {
+    //         _setup_executeTransaction();
+
+    //         assertEq(numberContract.num(), 0);
+
+    //         UserOperation[] memory userOp = _setupUserOpExecute(
+    //             accountSignerPKey,
+    //             bytes(""),
+    //             address(numberContract),
+    //             0,
+    //             abi.encodeWithSignature("setNum(uint256)", 42)
+    //         );
+
+    //         vm.expectRevert();
+    //         EntryPoint(entrypoint).handleOps(userOp, beneficiary);
+    //     }
+
+    //     /// @dev Revert: non-admin performs a state changing transaction directly via account contract.
+    //     function test_revert_executeTransaction_nonSigner_viaDirectCall() public {
+    //         _setup_executeTransaction();
+
+    //         address account = accountFactory.getAddress(accountAdmin, bytes(""));
+    //         address[] memory approvedTargets = new address[](1);
+    //         approvedTargets[0] = address(numberContract);
+    //         IAccountPermissions.SignerPermissionRequest memory permissionsReq = IAccountPermissions.SignerPermissionRequest(
+    //             accountSigner,
+    //             0,
+    //             approvedTargets,
+    //             1 ether,
+    //             0,
+    //             type(uint128).max,
+    //             0,
+    //             type(uint128).max,
+    //             uidCache
+    //         );
+
+    //         vm.prank(accountAdmin);
+    //         bytes memory sig = _signSignerPermissionRequest(permissionsReq);
+    //         ModularAccount(payable(account)).setPermissionsForSigner(permissionsReq, sig);
+
+    //         assertEq(numberContract.num(), 0);
+
+    //         vm.prank(accountSigner);
+    //         vm.expectRevert("Account: not admin or EntryPoint.");
+    //         ModularAccount(payable(account)).execute(
+    //             address(numberContract),
+    //             0,
+    //             abi.encodeWithSignature("setNum(uint256)", 42)
+    //         );
+    //     }
+
+    //     /*///////////////////////////////////////////////////////////////
+    //                 Test: receiving and sending native tokens
+    //     //////////////////////////////////////////////////////////////*/
+
+    //     /// @dev Send native tokens to an account.
+    //     function test_state_accountReceivesNativeTokens() public {
+    //         _setup_executeTransaction();
+
+    //         address account = accountFactory.getAddress(accountAdmin, bytes(""));
+
+    //         assertEq(address(account).balance, 0);
+
+    //         vm.prank(accountAdmin);
+    //         // solhint-disable-next-line avoid-low-level-calls
+    //         (bool success, bytes memory data) = payable(account).call{ value: 1000 }("");
+
+    //         // Silence warning: Return value of low-level calls not used.
+    //         (success, data) = (success, data);
+
+    //         assertEq(address(account).balance, 1000);
+    //     }
+
+    //     /// @dev Transfer native tokens out of an account.
+    //     function test_state_transferOutsNativeTokens() public {
+    //         _setup_executeTransaction();
+
+    //         uint256 value = 1000;
+
+    //         address account = accountFactory.getAddress(accountAdmin, bytes(""));
+    //         vm.prank(accountAdmin);
+    //         // solhint-disable-next-line avoid-low-level-calls
+    //         (bool success, bytes memory data) = payable(account).call{ value: value }("");
+    //         assertEq(address(account).balance, value);
+
+    //         // Silence warning: Return value of low-level calls not used.
+    //         (success, data) = (success, data);
+
+    //         address recipient = address(0x3456);
+
+    //         UserOperation[] memory userOp = _setupUserOpExecute(accountAdminPKey, bytes(""), recipient, value, bytes(""));
+
+    //         EntryPoint(entrypoint).handleOps(userOp, beneficiary);
+    //         assertEq(address(account).balance, 0);
+    //         assertEq(recipient.balance, value);
+    //     }
+
+    //     /// @dev Add and remove a deposit for the account from the Entrypoint.
+
+    //     function test_state_addAndWithdrawDeposit() public {
+    //         _setup_executeTransaction();
+
+    //         address account = accountFactory.getAddress(accountAdmin, bytes(""));
+
+    //         assertEq(EntryPoint(entrypoint).balanceOf(account), 0);
+
+    //         vm.prank(accountAdmin);
+    //         ModularAccount(payable(account)).addDeposit{ value: 1000 }();
+    //         assertEq(EntryPoint(entrypoint).balanceOf(account), 1000);
+
+    //         vm.prank(accountAdmin);
+    //         ModularAccount(payable(account)).withdrawDepositTo(payable(accountSigner), 500);
+    //         assertEq(EntryPoint(entrypoint).balanceOf(account), 500);
+    //     }
+
+    //     /*///////////////////////////////////////////////////////////////
+    //                 Test: receiving ERC-721 and ERC-1155 NFTs
+    //     //////////////////////////////////////////////////////////////*/
+
+    //     /// @dev Send an ERC-721 NFT to an account.
+    //     function test_state_receiveERC721NFT() public {
+    //         _setup_executeTransaction();
+    //         address account = accountFactory.getAddress(accountAdmin, bytes(""));
+
+    //         assertEq(erc721.balanceOf(account), 0);
+
+    //         erc721.mint(account, 1);
+
+    //         assertEq(erc721.balanceOf(account), 1);
+    //     }
+
+    //     /// @dev Send an ERC-1155 NFT to an account.
+    //     function test_state_receiveERC1155NFT() public {
+    //         _setup_executeTransaction();
+    //         address account = accountFactory.getAddress(accountAdmin, bytes(""));
+
+    //         assertEq(erc1155.balanceOf(account, 0), 0);
+
+    //         erc1155.mint(account, 0, 1);
+
+    //         assertEq(erc1155.balanceOf(account, 0), 1);
+    //     }
+
+    //     /*///////////////////////////////////////////////////////////////
+    //                 Test: setting contract metadata
+    //     //////////////////////////////////////////////////////////////*/
+
+    //     /// @dev Set contract metadata via admin or entrypoint.
+    //     function test_state_contractMetadata() public {
+    //         _setup_executeTransaction();
+    //         address account = accountFactory.getAddress(accountAdmin, bytes(""));
+
+    //         vm.prank(accountAdmin);
+    //         ModularAccount(payable(account)).setContractURI("https://example.com");
+    //         assertEq(ModularAccount(payable(account)).contractURI(), "https://example.com");
+
+    //         UserOperation[] memory userOp = _setupUserOpExecute(
+    //             accountAdminPKey,
+    //             bytes(""),
+    //             address(account),
+    //             0,
+    //             abi.encodeWithSignature("setContractURI(string)", "https://thirdweb.com")
+    //         );
+
+    //         EntryPoint(entrypoint).handleOps(userOp, beneficiary);
+    //         assertEq(ModularAccount(payable(account)).contractURI(), "https://thirdweb.com");
+
+    //         address[] memory approvedTargets = new address[](0);
+
+    //         IAccountPermissions.SignerPermissionRequest memory permissionsReq = IAccountPermissions.SignerPermissionRequest(
+    //             accountSigner,
+    //             0,
+    //             approvedTargets,
+    //             1 ether,
+    //             0,
+    //             type(uint128).max,
+    //             0,
+    //             type(uint128).max,
+    //             uidCache
+    //         );
+
+    //         vm.prank(accountAdmin);
+    //         bytes memory sig = _signSignerPermissionRequest(permissionsReq);
+    //         ModularAccount(payable(account)).setPermissionsForSigner(permissionsReq, sig);
+
+    //         UserOperation[] memory userOpViaSigner = _setupUserOpExecute(
+    //             accountSignerPKey,
+    //             bytes(""),
+    //             address(account),
+    //             0,
+    //             abi.encodeWithSignature("setContractURI(string)", "https://thirdweb.com")
+    //         );
+
+    //         vm.expectRevert();
+    //         EntryPoint(entrypoint).handleOps(userOpViaSigner, beneficiary);
+    //     }
+}


### PR DESCRIPTION
### Early draft of modular account architecture

## **Current Status**
 Modular Account
-> single interchangeable module used for validation
-> initialized upon `accountCreation`, and can be changed

SingleOwnerValidator
-> single owner validation module
-> owner initialized upon account deployment/enable
-> ownership can be transferred

## To Do
-> SessionKey validation module
-> multiple modules active at once
-> managed module activation
