### PR TITLE
Add auction winner check in collectAuctionTokens in EnglishAuctionsLogic.sol

### DIFF
--- a/contracts/prebuilts/marketplace/english-auctions/EnglishAuctionsLogic.sol
+++ b/contracts/prebuilts/marketplace/english-auctions/EnglishAuctionsLogic.sol
@@ -156,7 +156,7 @@ contract EnglishAuctionsLogic is IEnglishAuctions, ReentrancyGuard, ERC2771Conte
 
         require(_targetAuction.status != IEnglishAuctions.Status.CANCELLED, "Marketplace: invalid auction.");
         require(_targetAuction.endTimestamp <= block.timestamp, "Marketplace: auction still active.");
-        require(_winningBid.bidder != address(0), "Marketplace: no bids were made.");
+        require(_winningBid.bidder == _msgSender(), "Marketplace: not auction winner.");
 
         _closeAuctionForAuctionCreator(_targetAuction, _winningBid);
 

--- a/contracts/prebuilts/marketplace/marketplace-v3.md
+++ b/contracts/prebuilts/marketplace/marketplace-v3.md
@@ -487,7 +487,7 @@ The `EnglishAuctions` extension smart contract lets you sell NFTs (ERC-721 or ER
   | auctionId | The unique ID of the auction to collect the payout for. |
 - Criteria that must be satisfied
   - The auction must be expired.
-  - The caller must be the winning bidder.
+  - The caller must be the auction winner.
 
 ### `bidInAuction`
 


### PR DESCRIPTION
There was no check for _msgSender() in collectionAuctionTokens.
I have changed following line to check if the _msgSender() is auction winner.
`_winningBid.bidder != address(0)` is not necessary because _msgSender() cannot be zero address.

- original code
```solidity
require(_winningBid.bidder != address(0), "Marketplace: no bids were made.");
```
- suggested code
```solidity
require(_winningBid.bidder == _msgSender(), "Marketplace: not auction winner.");
```

I have also changed term `winning bidder` to `auction winner` in the marketplace-v3.md.
