### PR TITLE
Resolve: Emit appropriate events in initialize function #604

### DIFF
--- a/contracts/prebuilts/token/TokenERC1155.sol
+++ b/contracts/prebuilts/token/TokenERC1155.sol
@@ -173,6 +173,10 @@ contract TokenERC1155 is
 
         _setupRole(METADATA_ROLE, _defaultAdmin);
         _setRoleAdmin(METADATA_ROLE, METADATA_ROLE);
+
+        emit PrimarySaleRecipientUpdated(_primarySaleRecipient);
+        emit PlatformFeeInfoUpdated(_platformFeeRecipient, _platformFeeBps);
+        emit DefaultRoyalty(_royaltyRecipient, _royaltyBps);
     }
 
     ///     =====   Public functions  =====

--- a/contracts/prebuilts/token/TokenERC20.sol
+++ b/contracts/prebuilts/token/TokenERC20.sol
@@ -112,6 +112,9 @@ contract TokenERC20 is
         _setupRole(TRANSFER_ROLE, _defaultAdmin);
         _setupRole(MINTER_ROLE, _defaultAdmin);
         _setupRole(TRANSFER_ROLE, address(0));
+
+        emit PrimarySaleRecipientUpdated(_primarySaleRecipient);
+        emit PlatformFeeInfoUpdated(_platformFeeRecipient, _platformFeeBps);
     }
 
     /// @dev Returns the module type of the contract.

--- a/contracts/prebuilts/token/TokenERC721.sol
+++ b/contracts/prebuilts/token/TokenERC721.sol
@@ -154,6 +154,10 @@ contract TokenERC721 is
 
         _setupRole(TRANSFER_ROLE, _defaultAdmin);
         _setupRole(TRANSFER_ROLE, address(0));
+
+        emit PrimarySaleRecipientUpdated(_saleRecipient);
+        emit PlatformFeeInfoUpdated(_platformFeeRecipient, _platformFeeBps);
+        emit DefaultRoyalty(_royaltyRecipient, _royaltyBps);
     }
 
     ///     =====   Public functions  =====


### PR DESCRIPTION
Resolves https://github.com/thirdweb-dev/contracts/issues/604

Emits event for setting primary sale, platform fee and royalty info in the `initialize` function of `TokenERCxxx` contracts