### PR TITLE
Update ERC1155Base.sol spelling mistake.

### DIFF
--- a/contracts/base/ERC1155Base.sol
+++ b/contracts/base/ERC1155Base.sol
@@ -20,7 +20,7 @@ import "../lib/Strings.sol";
  *      - Ability to mint NFTs via the provided `mintTo` and `batchMintTo` functions.
  *
  *      - Contract metadata for royalty support on platforms such as OpenSea that use
- *        off-chain information to distribute roaylties.
+ *        off-chain information to distribute royalties.
  *
  *      - Ownership of the contract, with the ability to restrict certain functions to
  *        only be called by the contract's owner.


### PR DESCRIPTION
"Royalties" was spelled wrongly.