### PR TITLE
fix: auction payout can be locked before execute

### DIFF
--- a/contracts/prebuilts/marketplace/english-auctions/EnglishAuctionsLogic.sol
+++ b/contracts/prebuilts/marketplace/english-auctions/EnglishAuctionsLogic.sol
@@ -149,7 +149,6 @@ contract EnglishAuctionsLogic is IEnglishAuctions, ReentrancyGuard, ERC2771Conte
             !_englishAuctionsStorage().payoutStatus[_auctionId].paidOutBidAmount,
             "Marketplace: payout already completed."
         );
-        _englishAuctionsStorage().payoutStatus[_auctionId].paidOutBidAmount = true;
 
         Auction memory _targetAuction = _englishAuctionsStorage().auctions[_auctionId];
         Bid memory _winningBid = _englishAuctionsStorage().winningBid[_auctionId];
@@ -157,6 +156,8 @@ contract EnglishAuctionsLogic is IEnglishAuctions, ReentrancyGuard, ERC2771Conte
         require(_targetAuction.status != IEnglishAuctions.Status.CANCELLED, "Marketplace: invalid auction.");
         require(_targetAuction.endTimestamp <= block.timestamp, "Marketplace: auction still active.");
         require(_winningBid.bidder != address(0), "Marketplace: no bids were made.");
+
+        _englishAuctionsStorage().payoutStatus[_auctionId].paidOutBidAmount = true;
 
         _closeAuctionForAuctionCreator(_targetAuction, _winningBid);
 


### PR DESCRIPTION
In the `collectAuctionPayout` function, it becomes apparent that the variable `paidOutBidAmount` is set to `true` before the necessary `require` checks are performed. This has the potential to cause an issue where the auction creator does not receive their tokens, even if the auction is successful and has expired.

https://github.com/thirdweb-dev/contracts/blob/a9e647790a42e224d09e8b010b8bd892a0e4678c/contracts/prebuilts/marketplace/english-auctions/EnglishAuctionsLogic.sol#L147-L166

This PR aims to fix the potential issue.