### PR TITLE
fix: typos in documentation files

### DIFF
--- a/contracts/prebuilts/marketplace-legacy/marketplace.md
+++ b/contracts/prebuilts/marketplace-legacy/marketplace.md
@@ -7,7 +7,7 @@ The document is written for technical and non-technical readers. To ask further 
 ---
 ## Background
 
-The [thirdweb](https://thirdweb.com/) `Marketplace` is a market where where people can sell NFTs — [ERC 721](https://eips.ethereum.org/EIPS/eip-721) or [ERC 1155](https://eips.ethereum.org/EIPS/eip-1155) tokens — at a fixed price ( what we'll refer to as a "Direct listing"), or auction them (what we'll refer to as an "Auction listing").
+The [thirdweb](https://thirdweb.com/) `Marketplace` is a market where people can sell NFTs — [ERC 721](https://eips.ethereum.org/EIPS/eip-721) or [ERC 1155](https://eips.ethereum.org/EIPS/eip-1155) tokens — at a fixed price ( what we'll refer to as a "Direct listing"), or auction them (what we'll refer to as an "Auction listing").
 
 ### Direct Listings
 An NFT owner (or 'lister') can list their NFTs for sale at a fixed price. A potential buyer can buy the NFT for the specified price, or make an offer to buy the listed NFTs for a different price or currency, which the lister can choose to accept.

--- a/contracts/prebuilts/token/signatureMint.md
+++ b/contracts/prebuilts/token/signatureMint.md
@@ -17,7 +17,7 @@ Any external party can then present a smart contract implementing the 'signature
 
 The following diagram illustrates how the 'signature minting' flow looks like. For example, consider a webapp like [wombo.art](https://www.wombo.art/) which lets a user generate artwork on its website. Once a user has generated artwork on the wombo website, wombo can allow the user to mint their generated artwork as an NFT on wombo's own contract, where wombo can ensure that what the user will mint on wombo's contract is the intended generated artwork.
 
-![signaute-minting-diagram-1.png](/assets/signature-minting-diag-1.png)
+![signature-minting-diagram-1.png](/assets/signature-minting-diag-1.png)
 
 ### Why we're developing `Signature Minting`
 
@@ -91,7 +91,7 @@ function mintWithSignature(MintRequest calldata req, bytes calldata signature) e
 | req | The payload / mint request. |
 | signature | The signature produced by an account signing the mint request. |
 
-The contract implementing the 'signature minting' mechanism first recover's the address of the signer from the given payload i.e. `req` and the `signature`, and verifies that an authorized address has signed off this incoming mint request.
+The contract implementing the 'signature minting' mechanism first recovers the address of the signer from the given payload i.e. `req` and the `signature`, and verifies that an authorized address has signed off this incoming mint request.
 
 Once verified, tokens are minted according to the information specified in the payload.
 


### PR DESCRIPTION
This pull request contains changes to improve clarity, correctness and structure.

**Description correction:**
Corrected "market where where people" to "market where people".
Corrected "signaute" to "signature".
Corrected "recover's" to "recovers".

Please review the changes and let me know if any additional changes are needed.